### PR TITLE
version up

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: cellNexus
 Title: Queries the Human Cell Atlas
-Version: 1.6.11
+Version: 1.6.12
 Authors@R: c(
     person(
         "Stefano",

--- a/R/counts.R
+++ b/R/counts.R
@@ -636,18 +636,15 @@ group_to_data_container <- function(i, df, dir_prefix, features, grouping_column
     # Process specific to Pseudobulk
     # remove cell-level annotations
     cell_level_anno <- c("cell_id", "cell_type", "file_id_cellNexus_single_cell",
-                         "cell_annotation_blueprint_singler",
-                         "cell_annotation_monaco_singler", 
-                         "cell_annotation_azimuth_l2",
                          "cell_type_ontology_term_id",
                          "observation_joinid", "ensemble_joinid",
                          "nFeature_RNA", "data_driven_ensemble", "cell_type_unified",
-                         "empty_droplet", "observation_originalid")
+                         "empty_droplet", "observation_originalid", "alive", "scDblFinder.class")
     
     new_coldata <- df |>
       select(-dplyr::all_of(intersect(names(df), cell_level_anno))) |>
-      # Remove metacell annotations in pseudobulk
-      select(-contains("metacell")) |> 
+      # Remove metacell and single-cell level annotations in pseudobulk
+      select(-contains("metacell"), -matches("azimuth|monaco|blueprint|subsets_|high_")) |> 
       distinct() |>
       mutate(
         sample_identifier = glue("{sample_id}___{cell_type_unified_ensemble}"),

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -15,13 +15,13 @@ cache <- rlang::env(
 #' @export
 #' @return A character vector of URLs to parquet files to download
 #' @examples
-#' get_metadata_url("metadata.1.0.9.parquet")
+#' get_metadata_url("metadata.1.0.11.parquet")
 #' @references Mangiola, S., M. Milton, N. Ranathunga, C. S. N. Li-Wai-Suen, 
 #'   A. Odainic, E. Yang, W. Hutchison et al. "A multi-organ map of the human 
 #'   immune system across age, sex and ethnicity." bioRxiv (2023): 2023-06.
 #'   doi:10.1101/2023.06.08.542671.
 #' @source [Mangiola et al.,2023](https://www.biorxiv.org/content/10.1101/2023.06.08.542671v3)
-get_metadata_url <- function(databases = c("metadata.1.0.10.parquet")) {
+get_metadata_url <- function(databases = c("metadata.1.0.11.parquet")) {
   clear_old_metadata(updated_data = databases)
   glue::glue(
     "https://object-store.rc.nectar.org.au/v1/AUTH_06d6e008e3e642da99d806ba3ea629c5/cellNexus-metadata/{databases}")

--- a/man/get_metadata_url.Rd
+++ b/man/get_metadata_url.Rd
@@ -7,7 +7,7 @@
 \href{https://www.biorxiv.org/content/10.1101/2023.06.08.542671v3}{Mangiola et al.,2023}
 }
 \usage{
-get_metadata_url(databases = c("metadata.1.0.10.parquet"))
+get_metadata_url(databases = c("metadata.1.0.11.parquet"))
 }
 \arguments{
 \item{databases}{A character vector specifying the names of the metadata files.
@@ -20,7 +20,7 @@ A character vector of URLs to parquet files to download
 Returns the URLs for all metadata files
 }
 \examples{
-get_metadata_url("metadata.1.0.9.parquet")
+get_metadata_url("metadata.1.0.11.parquet")
 }
 \references{
 Mangiola, S., M. Milton, N. Ranathunga, C. S. N. Li-Wai-Suen,

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -261,7 +261,11 @@ test_that("get_single_cell_experiment() expect to get local counts only", {
 test_that("get_pseudobulk() syncs appropriate files", {
   temp <- tempfile()
   id <- "4329386e014727c59bcc66ed974e654c___1.h5ad"
-  meta <- get_metadata(cache_directory = temp) |> filter(file_id_cellNexus_pseudobulk == id)
+  meta <- get_metadata(cache_directory = temp) |> 
+    filter(empty_droplet == "FALSE",
+           alive == "TRUE",
+           scDblFinder.class !="doublet",
+           file_id_cellNexus_pseudobulk == id)
   
   # The remote dataset should have many genes
   sme <- get_pseudobulk(meta, cache_directory = temp)


### PR DESCRIPTION
- empty_droplet column to filter out empty droplets.
- alive column to exclude dead cells. 
- scDblFinder.class to identify and remove doublets.
- Reduce the number of pseudobulk files to improve query performance.
- version up to metadata.1.0.11.parquet   