### PR TITLE
version up

### DIFF
--- a/R/metadata.R
+++ b/R/metadata.R
@@ -11,17 +11,18 @@ cache <- rlang::env(
 
 #' Returns the URLs for all metadata files 
 #' @param databases A character vector specifying the names of the metadata files. 
-#' Default is c("metadata.1.0.9.parquet, "fibrosis.0.2.3.parquet", "prostate.0.1.0.parquet")
+#'   Download the specific metadata by defining the metadata version. The default is 
+#'   metadata.1.0.12.parquet
 #' @export
 #' @return A character vector of URLs to parquet files to download
 #' @examples
-#' get_metadata_url("metadata.1.0.11.parquet")
+#' get_metadata_url("metadata.1.0.12.parquet")
 #' @references Mangiola, S., M. Milton, N. Ranathunga, C. S. N. Li-Wai-Suen, 
 #'   A. Odainic, E. Yang, W. Hutchison et al. "A multi-organ map of the human 
 #'   immune system across age, sex and ethnicity." bioRxiv (2023): 2023-06.
 #'   doi:10.1101/2023.06.08.542671.
 #' @source [Mangiola et al.,2023](https://www.biorxiv.org/content/10.1101/2023.06.08.542671v3)
-get_metadata_url <- function(databases = c("metadata.1.0.11.parquet")) {
+get_metadata_url <- function(databases = c("metadata.1.0.12.parquet")) {
   clear_old_metadata(updated_data = databases)
   glue::glue(
     "https://object-store.rc.nectar.org.au/v1/AUTH_06d6e008e3e642da99d806ba3ea629c5/cellNexus-metadata/{databases}")

--- a/dev/2_execute_hpcell_on_census_and_defining_data_tranformation_mengyuan_version.R
+++ b/dev/2_execute_hpcell_on_census_and_defining_data_tranformation_mengyuan_version.R
@@ -414,6 +414,7 @@ cell_type_concensus_tbl = cell_type_concensus_tbl |> mutate(cell_type_unified_en
                                     ifelse(is.na(cell_type_unified_ensemble),
                                            "Unknown",
                                            cell_type_unified_ensemble)) 
+
 cell_type_concensus_tbl |> arrow::write_parquet("/vast/scratch/users/shen.m/cellNexus_run/cell_type_concensus_tbl_from_hpcell.parquet")
 
 # This command needs a big memory machine
@@ -438,6 +439,7 @@ cell_metadata_joined2 = cell_metadata_joined |> as_tibble() |>
   mutate(blueprint = ifelse(blueprint |> is.na(), "Other", blueprint)) |> 
   mutate(monaco = ifelse(monaco |> is.na(), "Other", monaco))
 
+# (!!!!) WHENEVER MAKE CHANGES, ALWAYS INCLUDE NEW Rhapsody DATA. Rhapsody TECH WERE UPDATED SEPARATELY in 2_1_rerun_hpcell_for_Rhapsody_targeted_panel.R. 
 cell_metadata_joined2 |>
   arrow::write_parquet("/vast/scratch/users/shen.m/cellNexus_run/cell_annotation.parquet")
 

--- a/dev/5_unify_and_update_sce_metadata.R
+++ b/dev/5_unify_and_update_sce_metadata.R
@@ -19,10 +19,10 @@ library(stringr)
 library(targets)
 library(purrr)
 
-DATE = "01-05-2025"
+DATE = "03-06-2025"
 # read cellxgene
 metadata <- tbl(dbConnect(duckdb::duckdb(), dbdir = ":memory:"),  
-    sql("SELECT * FROM read_parquet('/vast/scratch/users/shen.m/cellNexus_run/cell_metadata_cell_type_consensus_v1_0_11_filtered_missing_cells_mengyuan.parquet')") )
+    sql("SELECT * FROM read_parquet('/vast/scratch/users/shen.m/cellNexus_run/cell_metadata_cell_type_consensus_v1_0_12_filtered_missing_cells_updated_rhapsody.parquet')") )
 
 # Function of supporting Read parquet by duckdb, then do something, then write parquet. This avoids converting to tibble
 # @example
@@ -83,7 +83,8 @@ metadata <- metadata |> select(
                    -azimuth,
                    -blueprint,
                    -monaco,
-                   -matches("^scores")) |> 
+                   -matches("^scores"),
+                   -matches("coarse$")) |> 
   dplyr::rename(cell_annotation_blueprint_singler = blueprint_first_labels_fine,
          cell_annotation_monaco_singler = monaco_first_labels_fine,
          cell_annotation_azimuth_l2 = azimuth_predicted_celltype_l2) |> 
@@ -94,7 +95,7 @@ metadata <- metadata |> select(
 # (THESE TWO DATASETS DOESNT contain meaningful data - no observation_joinid etc), thus was excluded in the final metadata.
 metadata = metadata |> filter(!dataset_id %in% c("99950e99-2758-41d2-b2c9-643edcdf6d82", "9fcb0b73-c734-40a5-be9c-ace7eea401c9"))
 
-metadata_path = "/vast/scratch/users/shen.m/cellNexus/metadata.1.0.11.parquet"
+metadata_path = "/vast/scratch/users/shen.m/cellNexus/metadata.1.0.12.parquet"
 
 metadata |> mutate(atlas_id = paste0(atlas_id, "/", DATE) ) |>
   duckdb_write_parquet(path = metadata_path,

--- a/man/get_metadata_url.Rd
+++ b/man/get_metadata_url.Rd
@@ -7,11 +7,12 @@
 \href{https://www.biorxiv.org/content/10.1101/2023.06.08.542671v3}{Mangiola et al.,2023}
 }
 \usage{
-get_metadata_url(databases = c("metadata.1.0.11.parquet"))
+get_metadata_url(databases = c("metadata.1.0.12.parquet"))
 }
 \arguments{
 \item{databases}{A character vector specifying the names of the metadata files.
-Default is c("metadata.1.0.9.parquet, "fibrosis.0.2.3.parquet", "prostate.0.1.0.parquet")}
+Download the specific metadata by defining the metadata version. The default is
+metadata.1.0.12.parquet}
 }
 \value{
 A character vector of URLs to parquet files to download
@@ -20,7 +21,7 @@ A character vector of URLs to parquet files to download
 Returns the URLs for all metadata files
 }
 \examples{
-get_metadata_url("metadata.1.0.11.parquet")
+get_metadata_url("metadata.1.0.12.parquet")
 }
 \references{
 Mangiola, S., M. Milton, N. Ranathunga, C. S. N. Li-Wai-Suen,


### PR DESCRIPTION
- update to version 12
- `nCount_RNA` refers to the total number of counts for a cell in a sample
- empty droplet, alive, doublet and metacell annotations are updated for BD Rhapsody targeted panel
- fix inconsistent file id issue