### PR TITLE
Update CPM calculation deprecated warnings for bioconductor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: cellNexus
 Title: Queries the Human Cell Atlas
-Version: 0.99.18
+Version: 0.99.19
 Authors@R: c(
     person(
         "Stefano",
@@ -110,7 +110,7 @@ Imports:
     zellkonverter,
     anndataR,
     stringr,
-    scuttle,
+    Matrix,
     rclipboard
 Suggests:
     BiocStyle,

--- a/R/counts_per_million.R
+++ b/R/counts_per_million.R
@@ -17,11 +17,11 @@ get_counts_per_million <- function(sce, output_file) {
   selected_cols <- which(col_sums > 0 & col_sums < Inf)
   assay_name <- assays(sce) |>
     names()
+  counts_mat <- assay(sce[, selected_cols, drop = FALSE], assay_name)
+  lib_sizes <- Matrix::colSums(counts_mat) / 1e6
+  cpm_mat <- sweep(counts_mat, 2, lib_sizes, "/")
   sce <- SingleCellExperiment(list(
-    cpm = scuttle::calculateCPM(
-      sce[, selected_cols, drop = FALSE],
-      assay.type = assay_name
-    )
+    cpm = cpm_mat
   ))
   rownames(sce) <- rownames(sce[, selected_cols])
   colnames(sce) <- colnames(sce[, selected_cols])


### PR DESCRIPTION
Fix the warning message in:
https://github.com/Bioconductor/Contributions/issues/3984#issuecomment-4211597349

The warning occured because `normalizeCounts` is deprecated internally in `scuttle::calculateCPM()`, and bioconductor machine picked it up in R version 4.6.0 alpha version.

  