### PR TITLE
Update SCT assay warning message

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: cellNexus
 Title: Queries the Human Cell Atlas
-Version: 0.99.23
+Version: 0.99.24
 Authors@R: c(
     person(
         "Stefano",

--- a/R/counts.R
+++ b/R/counts.R
@@ -109,16 +109,16 @@ get_single_cell_experiment <- function(data,
     n_total <- nrow(raw_data)
     raw_data <- keep_quality_cells(raw_data)
     n_dropped <- n_total - nrow(raw_data)
-      if (n_dropped > 0) {
-        cli_alert_warning(paste(
-          "cellNexus says: {n_dropped} cells in your metadata did not pass quality",
-          "control (empty droplets, dead cells, or doublets) and have been excluded",
-          "automatically. The SCT assay is computed from quality-controlled cells only.",
-          "To suppress this warning, apply `keep_quality_cells()` to your metadata",
-          "before calling `get_single_cell_experiment()`."
-        ))
-      }
-    }
+    if (n_dropped > 0) {
+       cli_alert_warning(paste(
+         "cellNexus says: {n_dropped} cells in your metadata did not pass quality",
+         "control (empty droplets, dead cells, or doublets) and have been excluded",
+         "automatically. The SCT assay is computed from quality-controlled cells only.",
+         "To suppress this warning, apply `keep_quality_cells()` to your metadata",
+         "before calling `get_single_cell_experiment()`."
+       ))
+     }
+  }
 
   validate_data(raw_data, assays, cell_aggregation, cache_directory, repository, features)
 
@@ -396,6 +396,19 @@ get_metacell <- function(data,
       current_subdir
     }
 
+    # For SCT, accumulate dropped-cell counts so we can emit one consolidated
+    # warning after all files are read. For other assays the per-file warning
+    # fires as normal (dropped_counter = NULL).
+    cell_drop_state <- if (current_assay == "sct") {
+      e <- new.env(parent = emptyenv())
+      e$n_dropped <- 0L
+      e$n_files_affected <- 0L
+      e$sample_ids <- character(0)
+      e
+    } else {
+      NULL
+    }
+
     pb <- cli_progress_bar(glue("Reading {current_assay}"), total = length(groups))
 
     per_group <- map(seq_along(groups), function(i) {
@@ -406,13 +419,27 @@ get_metacell <- function(data,
         dir_prefix = dir_prefix,
         features = features,
         grouping_column = grouping_column,
-        metacell_column = cell_aggregation
+        metacell_column = cell_aggregation,
+        dropped_counter = cell_drop_state
       )
       cli_progress_update(id = pb)
       res
     })
 
     cli_progress_done(id = pb)
+
+    if (!is.null(cell_drop_state) && cell_drop_state$n_dropped > 0L) {
+      affected_ids <- paste(cell_drop_state$sample_ids, collapse = ", ")
+      cli_alert_warning(paste(
+        "cellNexus says: {cell_drop_state$n_dropped} cell(s) from your metadata are",
+        "absent from the SCT assay across {cell_drop_state$n_files_affected} file(s).",
+        "This is expected: SCT normalisation is run per sample and may fail for",
+        "samples with very few cells or extreme count distributions.",
+        "The returned object contains only cells from samples where SCT succeeded.",
+        "Affected sample_id(s): {affected_ids}."
+      ))
+    }
+
     per_group
   })
 
@@ -562,6 +589,11 @@ validate_data <- function(
 #' @param features The list of genes/rows of interest
 #' @param grouping_column A character vector of metadata column for grouping
 #' @param metacell_column A character vector of metacell column (e.g. "metacell_2", "metacell_4") from metadata.
+#' @param dropped_counter An optional environment with integer fields `n_dropped`,
+#'   `n_files_affected`, and a character field `sample_ids`. When provided, missing
+#'   cells are tallied into the environment in addition to the per-file warning,
+#'   allowing the caller to emit a single consolidated summary after all files are
+#'   read. If \code{NULL} (the default), only the per-file warning is issued.
 #' @return A `SummarizedExperiment` object
 #' @importFrom dplyr mutate filter select left_join distinct any_of all_of contains matches
 #' @importFrom SummarizedExperiment colData<-
@@ -573,7 +605,8 @@ validate_data <- function(
 #' @keywords internal
 #' @noRd
 group_to_data_container <- function(i, df, dir_prefix, features, grouping_column,
-                                    metacell_column = NULL) {
+                                    metacell_column = NULL,
+                                    dropped_counter = NULL) {
   experiment_path <- file.path(dir_prefix, df[[grouping_column]][1])
 
   if (!file.exists(experiment_path)) {
@@ -595,13 +628,20 @@ group_to_data_container <- function(i, df, dir_prefix, features, grouping_column
       intersect(df$cell_id)
 
     if (length(cells) < nrow(df)) {
-      cli_alert_warning(
-        paste(
-          "The number of cells in the SingleCellExperiment will be less than the number",
-          "of cells you have selected from the metadata.",
-          "Are cell IDs duplicated? Or, do cell IDs correspond to the counts file?"
-        )
-      )
+      cli_alert_warning(paste(
+        "The number of cells in the SingleCellExperiment will be less than the number",
+        "of cells you have selected from the metadata.",
+        "Are cell IDs duplicated? Or, do cell IDs correspond to the counts file?"
+      ))
+      if (!is.null(dropped_counter)) {
+        n_missing <- nrow(df) - length(cells)
+        dropped_counter$n_dropped <- dropped_counter$n_dropped + n_missing
+        dropped_counter$n_files_affected <- dropped_counter$n_files_affected + 1L
+        if ("sample_id" %in% names(df)) {
+          affected <- unique(df$sample_id[!df$cell_id %in% cells])
+          dropped_counter$sample_ids <- unique(c(dropped_counter$sample_ids, affected))
+        }
+      }
       df <- filter(df, .data$cell_id %in% cells)
     } else if (length(cells) > nrow(df)) {
       cli_abort("This should never happen")

--- a/R/counts.R
+++ b/R/counts.R
@@ -101,7 +101,26 @@ get_single_cell_experiment <- function(data,
     check_subset(c("cell_id", "file_id_cellNexus_single_cell", "atlas_id"), names(raw_data))
   )
 
-  validate_data(data, assays, cell_aggregation, cache_directory, repository, features)
+  # The SCT assay is precomputed from quality-controlled cells only, so when
+  # SCT is requested we must restrict to QC-passed cells to avoid silent
+  # cell-count mismatches. counts / cpm / rank cover all cells and need no
+  # such guard.
+  if ("sct" %in% assays) {
+    n_total <- nrow(raw_data)
+    raw_data <- keep_quality_cells(raw_data)
+    n_dropped <- n_total - nrow(raw_data)
+      if (n_dropped > 0) {
+        cli_alert_warning(paste(
+          "cellNexus says: {n_dropped} cells in your metadata did not pass quality",
+          "control (empty droplets, dead cells, or doublets) and have been excluded",
+          "automatically. The SCT assay is computed from quality-controlled cells only.",
+          "To suppress this warning, apply `keep_quality_cells()` to your metadata",
+          "before calling `get_single_cell_experiment()`."
+        ))
+      }
+    }
+
+  validate_data(raw_data, assays, cell_aggregation, cache_directory, repository, features)
 
   .fetch_experiments(
     raw_data = raw_data,


### PR DESCRIPTION
- Handled QC internally if it is not applied in `get_sce(assay = "sct")`
- Updated warnings of failed pre-computed SCT (number of cells, and sample ids)