### PR TITLE
fix: add CZI r-universe to R repos for pkgdown CI

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -19,6 +19,14 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
+      - name: Add CZI r-universe to R repos
+        shell: Rscript {0}
+        run: |
+          cat(
+            'options(repos = c(CZI = "https://chanzuckerberg.r-universe.dev", getOption("repos")))\n',
+            file = "~/.Rprofile", append = TRUE
+          )
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
@@ -26,7 +34,6 @@ jobs:
             any::rmarkdown
             any::knitr
           needs: website
-          extra-repositories: 'https://chanzuckerberg.r-universe.dev'
 
       - name: Install package
         run: R CMD INSTALL .


### PR DESCRIPTION
extra-repositories is not a valid input for r-lib/actions/setup-r-dependencies@v2 (the action silently ignores it), so cellxgene.census could never be resolved by pak. Add an explicit pre-step that appends chanzuckerberg.r-universe.dev to ~/.Rprofile so every subsequent Rscript process includes it in options("repos").

Verified locally: pak::lockfile_create() with deps::. fails without the repo and succeeds with it.