### PR TITLE
Add donor id metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: cellNexus
 Title: Queries the Human Cell Atlas
-Version: 0.99.30
+Version: 0.99.31
 Authors@R: c(
     person(
         "Stefano",

--- a/R/dev.R
+++ b/R/dev.R
@@ -240,7 +240,7 @@ hdf5_to_anndata <- function(input_directory, output_directory) {
 #' @param census_version Character scalar. Census LTS release in date format.
 #' @return NULL
 downsample_metadata <- function(
-  cellnexus_output = "sample_hca2024_v2.3.1.parquet",
+  cellnexus_output = "sample_hca2024_v2.3.2.parquet",
   census_version = "2024-07-01"
 ) {
   census_metadata <- get_census_metadata(census_version)

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -14,8 +14,8 @@ cache <- rlang::env(
 #' @keywords internal
 #' @noRd
 metadata_aliases <- c(
-  hca_2024 = "hca2024_v2.3.1.parquet",
-  hca_2025 = "hca2025_v0.1.0.parquet"
+  hca_2024 = "hca2024_v2.3.2.parquet",
+  hca_2025 = "hca2025_v0.1.1.parquet"
 )
 
 #' Returns the URLs for all metadata files
@@ -62,7 +62,7 @@ get_metadata_url <- function(databases = c("hca_2024")) {
 SAMPLE_DATABASE_URL <- c(
   paste0(
     "https://object-store.rc.nectar.org.au/v1/AUTH_06d6e008e3e642da99d806ba3ea629c5/",
-    "cellNexus-metadata/sample_hca2024_v2.3.1.parquet"
+    "cellNexus-metadata/sample_hca2024_v2.3.2.parquet"
   )
 )
 
@@ -127,9 +127,8 @@ SAMPLE_DATABASE_URL <- c(
 #'
 #' Through harmonisation and curation we introduced custom columns not present
 #' in the original CELLxGENE metadata:
-#'
-#' `cell_count`: Number of cells in a dataset.
-#' `feature_count`: Number of genes in a dataset.
+#' 
+#' `sample_id`: Sample identifier.
 #' `age_days`: Donor age in days.
 #' `tissue_groups`: Coarse tissue grouping for analysis.
 #' `empty_droplet`: Whether a cell is called an empty droplet from expressed-gene count per sample (default threshold 200; targeted panels may differ).
@@ -138,9 +137,15 @@ SAMPLE_DATABASE_URL <- c(
 #' `cell_type_unified_ensemble`: Consensus immune identity from Azimuth and SingleR (Blueprint, Monaco).
 #' `cell_annotation_azimuth_l2`: Azimuth cell annotation.
 #' `cell_annotation_blueprint_singler`: SingleR annotation (Blueprint).
-#' `cell_annotation_blueprint_monaco`: SingleR annotation (Monaco).
-#' `is_immune`: Whether a cell is an immune cell.
-#' `sample_heuristic`: Internal sample subdivision helper.
+#' `cell_annotation_monaco_singler`: SingleR annotation (Monaco).
+#' `subsets_Mito_percent`: Percent of each cell’s total counts coming from mitochondrial genes in a sample.
+#' `subsets_Ribo_percent`: Percent of each cell’s total counts coming from ribosomal genes in a sample.
+#' `high_mitochondrion`: TRUE if the cell’s mitochondrial percent exceeds the QC cutoff.
+#' `high_ribosome`: TRUE if the cell’s ribosomal percent exceeds the QC cutoff.
+#' `count_upper_bound`: Count capping threshold used in counts transformation.
+#' `inverse_transform`: Transformation method used in pre-processing pipeline.
+#' `nfeature_expressed_thresh`: Threshold of the number of expressed features per cell.
+#' `is_immune`: Curated logical flag for immune-cell context.
 #' `file_id_cellNexus_single_cell`: Internal file id for single-cell layers.
 #' `file_id_cellNexus_pseudobulk`: Internal file id for pseudobulk layers.
 #' `sample_id`: Harmonised sample identifier.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 cellNexus
 ================
+Mangiola et al.
 
 <!-- badges: start -->
 
@@ -39,28 +40,50 @@ CELLxGENE releases.
 
 <img src="man/figures/logo.png" width="120x" height="139px" />
 
+
 </div>
 
 <div class="figure">
 
 <img src="man/figures/svcf_logo.jpeg" width="155x" height="58px" />
-<img src="man/figures/czi_logo.png" width="129px" height="58px" />
-<img src="man/figures/bioconductor_logo.jpg" width="202px" height="58px" />
-<img src="man/figures/vca_logo.png" width="219px" height="58px" />
-<img src="man/figures/nectar_logo.png" width="180px" height="58px" />
-<img src="man/figures/CSL_Limited_logo.svg.png" width="120px" height="58px" />
 
 
 </div>
 
-# Repositories
+<div class="figure">
 
-### R API: [here](https://github.com/MangiolaLaboratory/cellNexus)
+<img src="man/figures/czi_logo.png" width="129px" height="58px" />
 
-### Python API: [here](https://github.com/MangiolaLaboratory/cellNexusPy/)
 
-### Article code: [here](https://github.com/MangiolaLaboratory/cellNexus_article)
+</div>
 
+<div class="figure">
+
+<img src="man/figures/bioconductor_logo.jpg" width="202px" height="58px" />
+
+
+</div>
+
+<div class="figure">
+
+<img src="man/figures/vca_logo.png" width="219px" height="58px" />
+
+
+</div>
+
+<div class="figure">
+
+<img src="man/figures/nectar_logo.png" width="180px" height="58px" />
+
+
+</div>
+
+<div class="figure">
+
+<img src="man/figures/CSL_Limited_logo.svg.png" width="120px" height="58px" />
+
+
+</div>
 
 # Query interface
 
@@ -93,7 +116,13 @@ saved to `get_default_cache_dir()` unless a custom path is provided via
 the cache_directory argument. The `metadata` variable can then be
 re-used for all subsequent queries.
 
-The unified pseudobulk AnnData object was pre-generated outside of this vignette applying quality control and retaining at least 15,000 intersecting genes across samples and hosted on Zenodo to avoid lengthy recompilation. Download the latest version: [pseudobulk_se.h5ad](https://zenodo.org/records/21633607/files/pseudobulk_se.h5ad?download=1). For all versions: [10.5281/zenodo.21633607](https://zenodo.org/records/21633607).
+The unified pseudobulk AnnData object was pre-generated outside of this
+vignette applying quality control and retaining at least 15,000
+intersecting genes across samples and hosted on Zenodo to avoid lengthy
+recompilation. Download the latest version:
+[pseudobulk_se.h5ad](https://zenodo.org/records/21633607/files/pseudobulk_se.h5ad?download=1).
+For all versions:
+[10.5281/zenodo.21633607](https://zenodo.org/records/21633607).
 
 The following sections demonstrate the metadata, quality control,
 generation of raw and normalised counts, and pseudobulk construction for
@@ -102,27 +131,27 @@ the specified query.
 ``` r
 metadata <- get_metadata()
 metadata
-#> # Source:   SQL [?? x 37]
+#> # Source:   SQL [?? x 31]
 #> # Database: DuckDB 1.4.3 [unknown@Linux 5.14.0-570.123.1.el9_6.x86_64:R 4.5.3/:memory:]
-#>    cell_id observation_joinid dataset_id   sample_id sample_ experiment___ run_from_cell_id sample_heuristic age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA
-#>      <dbl> <chr>              <chr>        <chr>     <chr>   <chr>         <chr>            <chr>               <int> <chr>                          <int>      <dbl>
-#>  1       1 `;+Wwc*oS9         574e9f9e-f8… b290d7ef… b290d7… ""            <NA>             BPH556PrGA2_Fco…    25915 prostate                        1025      113. 
-#>  2       1 s<8rT5qe3X         574e9f9e-f8… b290d7ef… b290d7… ""            <NA>             BPH556PrGA2_Fco…    25915 prostate                        2586       77.6
-#>  3       2 Se=|eIq*={         574e9f9e-f8… b290d7ef… b290d7… ""            <NA>             BPH556PrGA2_Fco…    25915 prostate                         992       57.6
-#>  4       2 dcNO`ReB5o         574e9f9e-f8… b290d7ef… b290d7… ""            <NA>             BPH556PrGA2_Fco…    25915 prostate                        2002      163. 
-#>  5       3 F_Jf~Pzj<!         574e9f9e-f8… b290d7ef… b290d7… ""            <NA>             BPH556PrGA2_Fco…    25915 prostate                         730       93.6
-#>  6      16 i(U>N;cU4_         574e9f9e-f8… b290d7ef… b290d7… ""            <NA>             BPH556PrGA2_Fco…    25915 prostate                         718      342. 
-#>  7       4 MK~^fbPVCl         574e9f9e-f8… b290d7ef… b290d7… ""            <NA>             BPH556PrGA2_Fco…    25915 prostate                         846       99.8
-#>  8       4 J+o&MJmtR5         574e9f9e-f8… b290d7ef… b290d7… ""            <NA>             BPH556PrGA2_Fco…    25915 prostate                         829      123. 
-#>  9      12 $LL!IWeW`F         574e9f9e-f8… b290d7ef… b290d7… ""            <NA>             BPH556PrGA2_Fco…    25915 prostate                        2482       61.8
-#> 10      18 $zB;$PErEP         574e9f9e-f8… b290d7ef… b290d7… ""            <NA>             BPH556PrGA2_Fco…    25915 prostate                         828       86.6
+#>    cell_id observation_joinid dataset_id             sample_id donor_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA
+#>      <dbl> <chr>              <chr>                  <chr>     <chr>       <int> <chr>                          <int>      <dbl>
+#>  1       1 `;+Wwc*oS9         574e9f9e-f8b4-41ef-bf… b290d7ef… BPH556      25915 prostate                        1025      113. 
+#>  2       1 s<8rT5qe3X         574e9f9e-f8b4-41ef-bf… b290d7ef… BPH556      25915 prostate                        2586       77.6
+#>  3       2 Se=|eIq*={         574e9f9e-f8b4-41ef-bf… b290d7ef… BPH556      25915 prostate                         992       57.6
+#>  4       2 dcNO`ReB5o         574e9f9e-f8b4-41ef-bf… b290d7ef… BPH556      25915 prostate                        2002      163. 
+#>  5       3 F_Jf~Pzj<!         574e9f9e-f8b4-41ef-bf… b290d7ef… BPH556      25915 prostate                         730       93.6
+#>  6      16 i(U>N;cU4_         574e9f9e-f8b4-41ef-bf… b290d7ef… BPH556      25915 prostate                         718      342. 
+#>  7       4 MK~^fbPVCl         574e9f9e-f8b4-41ef-bf… b290d7ef… BPH556      25915 prostate                         846       99.8
+#>  8       4 J+o&MJmtR5         574e9f9e-f8b4-41ef-bf… b290d7ef… BPH556      25915 prostate                         829      123. 
+#>  9      12 $LL!IWeW`F         574e9f9e-f8b4-41ef-bf… b290d7ef… BPH556      25915 prostate                        2482       61.8
+#> 10      18 $zB;$PErEP         574e9f9e-f8b4-41ef-bf… b290d7ef… BPH556      25915 prostate                         828       86.6
 #> # ℹ more rows
 #> # ℹ abbreviated name: ¹​nFeature_expressed_in_sample
-#> # ℹ 25 more variables: empty_droplet <lgl>, cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>, subsets_Ribo_percent <int>,
-#> #   high_mitochondrion <lgl>, high_ribosome <lgl>, scDblFinder.class <chr>, sample_chunk <int>, cell_chunk <int>, sample_pseudobulk_chunk <int>,
-#> #   file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>, inverse_transform <chr>,
-#> #   alive <lgl>, cell_annotation_blueprint_singler <chr>, cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>,
-#> #   low_confidence_ethnicity <chr>, .aggregated_cells <int>, imputed_ethnicity <chr>, atlas_id <chr>
+#> # ℹ 22 more variables: empty_droplet <lgl>, cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>,
+#> #   subsets_Ribo_percent <int>, high_mitochondrion <lgl>, high_ribosome <lgl>, alive <lgl>, scDblFinder.class <chr>,
+#> #   file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>,
+#> #   nfeature_expressed_thresh <dbl>, inverse_transform <chr>, cell_annotation_blueprint_singler <chr>,
+#> #   cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>, …
 ```
 
 ## Quality control
@@ -177,16 +206,16 @@ metadata |>
 #> # Database: DuckDB 1.4.3 [unknown@Linux 5.14.0-570.123.1.el9_6.x86_64:R 4.5.3/:memory:]
 #>    tissue                      cell_type_unified_ensemble
 #>    <chr>                       <chr>                     
-#>  1 subcutaneous adipose tissue nkt                       
-#>  2 subcutaneous adipose tissue muscle                    
-#>  3 subcutaneous adipose tissue macrophage                
-#>  4 subcutaneous adipose tissue cd8 tem                   
-#>  5 subcutaneous adipose tissue cd16 mono                 
-#>  6 subcutaneous adipose tissue cd14 mono                 
-#>  7 subcutaneous adipose tissue b naive                   
-#>  8 subcutaneous adipose tissue cd4 th1/th17 em           
-#>  9 subcutaneous adipose tissue granulocyte               
-#> 10 subcutaneous adipose tissue cd4 naive                 
+#>  1 transition zone of prostate cdc                       
+#>  2 transition zone of prostate epithelial                
+#>  3 transition zone of prostate b memory                  
+#>  4 transition zone of prostate endothelial               
+#>  5 transition zone of prostate monocytic                 
+#>  6 transition zone of prostate dc                        
+#>  7 transition zone of prostate nk                        
+#>  8 transition zone of prostate other                     
+#>  9 transition zone of prostate stromal                   
+#> 10 transition zone of prostate b                         
 #> # ℹ more rows
 ```
 
@@ -208,11 +237,9 @@ single_cell_counts <-
 #> ℹ Synchronising files
 #> ℹ Reading files.
 #> 
-Reading counts ■■■■                              10% | ETA: 11s
+Reading counts ■■■■■■■                           20% | ETA:  9s
 
-Reading counts ■■■■■■■                           20% | ETA:  7s
-
-Reading counts ■■■■■■■■■■                        30% | ETA:  6s
+Reading counts ■■■■■■■■■■                        30% | ETA:  7s
 
 Reading counts ■■■■■■■■■■■■■                     40% | ETA:  5s
 
@@ -230,27 +257,27 @@ Reading counts ■■■■■■■■■■■■■■■■■■■■■�
 ℹ Compiling Experiment.
 
 single_cell_counts
-#> # A SingleCellExperiment-tibble abstraction: 2,806 × 60
-#> # [90mFeatures=33145 | Cells=2806 | Assays=counts[0m
-#>    .cell observation_joinid dataset_id     sample_id sample_ experiment___ run_from_cell_id sample_heuristic age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA
-#>    <chr> <chr>              <chr>          <chr>     <chr>   <chr>         <chr>            <chr>               <int> <chr>                          <int>      <dbl>
-#>  1 80_1  zz-!e5_XAo         842c6f5d-4a94… 1de3f3ba… 1de3f3… ""            <NA>             7fabaf1c-52fd-4…    14600 breast                          1749      10.8 
-#>  2 81_1  -mb&DWckf(         842c6f5d-4a94… 1de3f3ba… 1de3f3… ""            <NA>             7fabaf1c-52fd-4…    14600 breast                          1993      12.4 
-#>  3 73_1  z_=CTOs4{z         842c6f5d-4a94… 4b5e66fa… 4b5e66… ""            <NA>             04983012-bb56-4…    14600 breast                          2866      10.3 
-#>  4 74_1  fNzorxA`Mf         842c6f5d-4a94… 4b5e66fa… 4b5e66… ""            <NA>             04983012-bb56-4…    14600 breast                          1942       7.58
-#>  5 76_1  bTlx!HK=oS         842c6f5d-4a94… 52ab9222… 52ab92… ""            <NA>             7ce86149-8906-4…    14600 breast                          1671       9.65
-#>  6 77_1  E4g5+)v;AV         842c6f5d-4a94… 52ab9222… 52ab92… ""            <NA>             7ce86149-8906-4…    14600 breast                          2340      11.9 
-#>  7 78_1  +q?29B%2nH         842c6f5d-4a94… 52ab9222… 52ab92… ""            <NA>             7ce86149-8906-4…    14600 breast                          1714      13.2 
-#>  8 79_1  zuJ#MBMWy;         842c6f5d-4a94… 52ab9222… 52ab92… ""            <NA>             7ce86149-8906-4…    14600 breast                          1506      12.3 
-#>  9 1_1   I8a42<8st4         842c6f5d-4a94… 184fa234… 184fa2… ""            <NA>             c2aa4d8d-e9df-4…    14600 breast                          3395      11.8 
-#> 10 72_1  8wGs7JgUjj         842c6f5d-4a94… 6b194412… 6b1944… ""            <NA>             b3ff1aad-40fd-4…    14600 breast                          2548      13.1 
+#> # A SingleCellExperiment-tibble abstraction: 2,806 × 54
+#> # [90mFeatures=33145 | Cells=2806 | Assays=counts[0m
+#>    .cell observation_joinid dataset_id sample_id donor_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA empty_droplet
+#>    <chr> <chr>              <chr>      <chr>     <chr>       <int> <chr>                          <int>      <dbl> <lgl>        
+#>  1 80_1  zz-!e5_XAo         842c6f5d-… 1de3f3ba… P58         14600 breast                          1749      10.8  FALSE        
+#>  2 81_1  -mb&DWckf(         842c6f5d-… 1de3f3ba… P58         14600 breast                          1993      12.4  FALSE        
+#>  3 73_1  z_=CTOs4{z         842c6f5d-… 4b5e66fa… P39         14600 breast                          2866      10.3  FALSE        
+#>  4 74_1  fNzorxA`Mf         842c6f5d-… 4b5e66fa… P39         14600 breast                          1942       7.58 FALSE        
+#>  5 1_1   I8a42<8st4         842c6f5d-… 184fa234… P65         14600 breast                          3395      11.8  FALSE        
+#>  6 72_1  8wGs7JgUjj         842c6f5d-… 6b194412… P39         14600 breast                          2548      13.1  FALSE        
+#>  7 75_1  F9G7A+GgjA         842c6f5d-… db5a69ed… P40         14600 breast                          1291      10.2  FALSE        
+#>  8 76_1  bTlx!HK=oS         842c6f5d-… 52ab9222… P58         14600 breast                          1671       9.65 FALSE        
+#>  9 77_1  E4g5+)v;AV         842c6f5d-… 52ab9222… P58         14600 breast                          2340      11.9  FALSE        
+#> 10 78_1  +q?29B%2nH         842c6f5d-… 52ab9222… P58         14600 breast                          1714      13.2  FALSE        
 #> # ℹ 2,796 more rows
 #> # ℹ abbreviated name: ¹​nFeature_expressed_in_sample
-#> # ℹ 48 more variables: empty_droplet <lgl>, cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>, subsets_Ribo_percent <int>,
-#> #   high_mitochondrion <lgl>, high_ribosome <lgl>, scDblFinder.class <chr>, sample_chunk <int>, cell_chunk <int>, sample_pseudobulk_chunk <int>,
-#> #   file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>, inverse_transform <chr>,
-#> #   alive <lgl>, cell_annotation_blueprint_singler <chr>, cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>,
-#> #   low_confidence_ethnicity <chr>, .aggregated_cells <int>, imputed_ethnicity <chr>, atlas_id <chr>, dataset_version_id <chr>, collection_id <chr>, …
+#> # ℹ 44 more variables: cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>,
+#> #   subsets_Ribo_percent <int>, high_mitochondrion <lgl>, high_ribosome <lgl>, alive <lgl>, scDblFinder.class <chr>,
+#> #   file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>,
+#> #   nfeature_expressed_thresh <dbl>, inverse_transform <chr>, cell_annotation_blueprint_singler <chr>,
+#> #   cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>, …
 ```
 
 ### Query counts scaled per million
@@ -269,7 +296,7 @@ single_cell_cpm <-
 #> ℹ Synchronising files
 #> ℹ Reading files.
 #> 
-Reading cpm ■■■■■■■                           20% | ETA:  5s
+Reading cpm ■■■■■■■                           20% | ETA:  6s
 
 Reading cpm ■■■■■■■■■■                        30% | ETA:  4s
 
@@ -289,27 +316,27 @@ Reading cpm ■■■■■■■■■■■■■■■■■■■■■■�
 ℹ Compiling Experiment.
 
 single_cell_cpm
-#> # A SingleCellExperiment-tibble abstraction: 2,806 × 60
-#> # [90mFeatures=33145 | Cells=2806 | Assays=cpm[0m
-#>    .cell observation_joinid dataset_id     sample_id sample_ experiment___ run_from_cell_id sample_heuristic age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA
-#>    <chr> <chr>              <chr>          <chr>     <chr>   <chr>         <chr>            <chr>               <int> <chr>                          <int>      <dbl>
-#>  1 80_1  zz-!e5_XAo         842c6f5d-4a94… 1de3f3ba… 1de3f3… ""            <NA>             7fabaf1c-52fd-4…    14600 breast                          1749      10.8 
-#>  2 81_1  -mb&DWckf(         842c6f5d-4a94… 1de3f3ba… 1de3f3… ""            <NA>             7fabaf1c-52fd-4…    14600 breast                          1993      12.4 
-#>  3 73_1  z_=CTOs4{z         842c6f5d-4a94… 4b5e66fa… 4b5e66… ""            <NA>             04983012-bb56-4…    14600 breast                          2866      10.3 
-#>  4 74_1  fNzorxA`Mf         842c6f5d-4a94… 4b5e66fa… 4b5e66… ""            <NA>             04983012-bb56-4…    14600 breast                          1942       7.58
-#>  5 76_1  bTlx!HK=oS         842c6f5d-4a94… 52ab9222… 52ab92… ""            <NA>             7ce86149-8906-4…    14600 breast                          1671       9.65
-#>  6 77_1  E4g5+)v;AV         842c6f5d-4a94… 52ab9222… 52ab92… ""            <NA>             7ce86149-8906-4…    14600 breast                          2340      11.9 
-#>  7 78_1  +q?29B%2nH         842c6f5d-4a94… 52ab9222… 52ab92… ""            <NA>             7ce86149-8906-4…    14600 breast                          1714      13.2 
-#>  8 79_1  zuJ#MBMWy;         842c6f5d-4a94… 52ab9222… 52ab92… ""            <NA>             7ce86149-8906-4…    14600 breast                          1506      12.3 
-#>  9 1_1   I8a42<8st4         842c6f5d-4a94… 184fa234… 184fa2… ""            <NA>             c2aa4d8d-e9df-4…    14600 breast                          3395      11.8 
-#> 10 72_1  8wGs7JgUjj         842c6f5d-4a94… 6b194412… 6b1944… ""            <NA>             b3ff1aad-40fd-4…    14600 breast                          2548      13.1 
+#> # A SingleCellExperiment-tibble abstraction: 2,806 × 54
+#> # [90mFeatures=33145 | Cells=2806 | Assays=cpm[0m
+#>    .cell observation_joinid dataset_id sample_id donor_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA empty_droplet
+#>    <chr> <chr>              <chr>      <chr>     <chr>       <int> <chr>                          <int>      <dbl> <lgl>        
+#>  1 76_1  bTlx!HK=oS         842c6f5d-… 52ab9222… P58         14600 breast                          1671       9.65 FALSE        
+#>  2 77_1  E4g5+)v;AV         842c6f5d-… 52ab9222… P58         14600 breast                          2340      11.9  FALSE        
+#>  3 78_1  +q?29B%2nH         842c6f5d-… 52ab9222… P58         14600 breast                          1714      13.2  FALSE        
+#>  4 79_1  zuJ#MBMWy;         842c6f5d-… 52ab9222… P58         14600 breast                          1506      12.3  FALSE        
+#>  5 1_1   I8a42<8st4         842c6f5d-… 184fa234… P65         14600 breast                          3395      11.8  FALSE        
+#>  6 72_1  8wGs7JgUjj         842c6f5d-… 6b194412… P39         14600 breast                          2548      13.1  FALSE        
+#>  7 75_1  F9G7A+GgjA         842c6f5d-… db5a69ed… P40         14600 breast                          1291      10.2  FALSE        
+#>  8 80_1  zz-!e5_XAo         842c6f5d-… 1de3f3ba… P58         14600 breast                          1749      10.8  FALSE        
+#>  9 81_1  -mb&DWckf(         842c6f5d-… 1de3f3ba… P58         14600 breast                          1993      12.4  FALSE        
+#> 10 73_1  z_=CTOs4{z         842c6f5d-… 4b5e66fa… P39         14600 breast                          2866      10.3  FALSE        
 #> # ℹ 2,796 more rows
 #> # ℹ abbreviated name: ¹​nFeature_expressed_in_sample
-#> # ℹ 48 more variables: empty_droplet <lgl>, cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>, subsets_Ribo_percent <int>,
-#> #   high_mitochondrion <lgl>, high_ribosome <lgl>, scDblFinder.class <chr>, sample_chunk <int>, cell_chunk <int>, sample_pseudobulk_chunk <int>,
-#> #   file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>, inverse_transform <chr>,
-#> #   alive <lgl>, cell_annotation_blueprint_singler <chr>, cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>,
-#> #   low_confidence_ethnicity <chr>, .aggregated_cells <int>, imputed_ethnicity <chr>, atlas_id <chr>, dataset_version_id <chr>, collection_id <chr>, …
+#> # ℹ 44 more variables: cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>,
+#> #   subsets_Ribo_percent <int>, high_mitochondrion <lgl>, high_ribosome <lgl>, alive <lgl>, scDblFinder.class <chr>,
+#> #   file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>,
+#> #   nfeature_expressed_thresh <dbl>, inverse_transform <chr>, cell_annotation_blueprint_singler <chr>,
+#> #   cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>, …
 ```
 
 ### Query SCT normalised counts
@@ -345,7 +372,7 @@ Reading sct ■■■■■■■■■■■■■■■■                  50
 ! The number of cells in the SingleCellExperiment will be less than the number of cells you have selected from the metadata. Are cell IDs duplicated? Or, do cell IDs correspond to the counts file?
 #> Reading sct ■■■■■■■■■■■■■■■■                  50% | ETA:  3s
 
-Reading sct ■■■■■■■■■■■■■■■■■■■               60% | ETA:  3s
+Reading sct ■■■■■■■■■■■■■■■■■■■               60% | ETA:  2s
 
 Reading sct ■■■■■■■■■■■■■■■■■■■■■■            70% | ETA:  2s
 
@@ -362,27 +389,27 @@ Reading sct ■■■■■■■■■■■■■■■■■■■■■■�
 #> ℹ Compiling Experiment.
 
 single_cell_sct
-#> # A SingleCellExperiment-tibble abstraction: 1,193 × 60
-#> # [90mFeatures=33145 | Cells=1193 | Assays=sct[0m
-#>    .cell observation_joinid dataset_id     sample_id sample_ experiment___ run_from_cell_id sample_heuristic age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA
-#>    <chr> <chr>              <chr>          <chr>     <chr>   <chr>         <chr>            <chr>               <int> <chr>                          <int>      <dbl>
-#>  1 80_1  zz-!e5_XAo         842c6f5d-4a94… 1de3f3ba… 1de3f3… ""            <NA>             7fabaf1c-52fd-4…    14600 breast                          1749      10.8 
-#>  2 81_1  -mb&DWckf(         842c6f5d-4a94… 1de3f3ba… 1de3f3… ""            <NA>             7fabaf1c-52fd-4…    14600 breast                          1993      12.4 
-#>  3 73_1  z_=CTOs4{z         842c6f5d-4a94… 4b5e66fa… 4b5e66… ""            <NA>             04983012-bb56-4…    14600 breast                          2866      10.3 
-#>  4 74_1  fNzorxA`Mf         842c6f5d-4a94… 4b5e66fa… 4b5e66… ""            <NA>             04983012-bb56-4…    14600 breast                          1942       7.58
-#>  5 1_1   I8a42<8st4         842c6f5d-4a94… 184fa234… 184fa2… ""            <NA>             c2aa4d8d-e9df-4…    14600 breast                          3395      11.8 
-#>  6 72_1  8wGs7JgUjj         842c6f5d-4a94… 6b194412… 6b1944… ""            <NA>             b3ff1aad-40fd-4…    14600 breast                          2548      13.1 
-#>  7 75_1  F9G7A+GgjA         842c6f5d-4a94… db5a69ed… db5a69… ""            <NA>             49beb83c-66a1-4…    14600 breast                          1291      10.2 
-#>  8 1_2   >8f0}-gXFY         842c6f5d-4a94… 81d05f17… 81d05f… ""            <NA>             b866c1d4-3dfd-4…    14600 breast                          2513      13.3 
-#>  9 22_2  2lQ`<&l3-A         842c6f5d-4a94… 30967738… 309677… ""            <NA>             7d4045ff-3f48-4…    14600 breast                          2058       9.91
-#> 10 5_2   +p4uNj_7$S         842c6f5d-4a94… a91e6814… a91e68… ""            <NA>             700a819c-03f9-4…    14600 breast                          1870      11.1 
+#> # A SingleCellExperiment-tibble abstraction: 1,193 × 54
+#> # [90mFeatures=33145 | Cells=1193 | Assays=sct[0m
+#>    .cell observation_joinid dataset_id sample_id donor_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA empty_droplet
+#>    <chr> <chr>              <chr>      <chr>     <chr>       <int> <chr>                          <int>      <dbl> <lgl>        
+#>  1 80_1  zz-!e5_XAo         842c6f5d-… 1de3f3ba… P58         14600 breast                          1749      10.8  FALSE        
+#>  2 81_1  -mb&DWckf(         842c6f5d-… 1de3f3ba… P58         14600 breast                          1993      12.4  FALSE        
+#>  3 72_1  8wGs7JgUjj         842c6f5d-… 6b194412… P39         14600 breast                          2548      13.1  FALSE        
+#>  4 75_1  F9G7A+GgjA         842c6f5d-… db5a69ed… P40         14600 breast                          1291      10.2  FALSE        
+#>  5 73_1  z_=CTOs4{z         842c6f5d-… 4b5e66fa… P39         14600 breast                          2866      10.3  FALSE        
+#>  6 74_1  fNzorxA`Mf         842c6f5d-… 4b5e66fa… P39         14600 breast                          1942       7.58 FALSE        
+#>  7 1_1   I8a42<8st4         842c6f5d-… 184fa234… P65         14600 breast                          3395      11.8  FALSE        
+#>  8 1_2   >8f0}-gXFY         842c6f5d-… 81d05f17… P63         14600 breast                          2513      13.3  FALSE        
+#>  9 22_2  2lQ`<&l3-A         842c6f5d-… 30967738… P57         14600 breast                          2058       9.91 FALSE        
+#> 10 23_2  sqV-|vcI4R         842c6f5d-… d8ecdd92… P41         14600 breast                          2375      13.7  FALSE        
 #> # ℹ 1,183 more rows
 #> # ℹ abbreviated name: ¹​nFeature_expressed_in_sample
-#> # ℹ 48 more variables: empty_droplet <lgl>, cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>, subsets_Ribo_percent <int>,
-#> #   high_mitochondrion <lgl>, high_ribosome <lgl>, scDblFinder.class <chr>, sample_chunk <int>, cell_chunk <int>, sample_pseudobulk_chunk <int>,
-#> #   file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>, inverse_transform <chr>,
-#> #   alive <lgl>, cell_annotation_blueprint_singler <chr>, cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>,
-#> #   low_confidence_ethnicity <chr>, .aggregated_cells <int>, imputed_ethnicity <chr>, atlas_id <chr>, dataset_version_id <chr>, collection_id <chr>, …
+#> # ℹ 44 more variables: cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>,
+#> #   subsets_Ribo_percent <int>, high_mitochondrion <lgl>, high_ribosome <lgl>, alive <lgl>, scDblFinder.class <chr>,
+#> #   file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>,
+#> #   nfeature_expressed_thresh <dbl>, inverse_transform <chr>, cell_annotation_blueprint_singler <chr>,
+#> #   cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>, …
 ```
 
 ### Query pseudobulk
@@ -400,13 +427,13 @@ pseudobulk_counts <-
 #> ℹ Synchronising files
 #> ℹ Reading files.
 #> 
-Reading counts ■■■■■                             14% | ETA:  8s
+Reading counts ■■■■■                             14% | ETA:  9s
 
-Reading counts ■■■■■■■■■■                        29% | ETA: 11s
+Reading counts ■■■■■■■■■■                        29% | ETA:  9s
 
-Reading counts ■■■■■■■■■■■■■■                    43% | ETA:  9s
+Reading counts ■■■■■■■■■■■■■■                    43% | ETA:  7s
 
-Reading counts ■■■■■■■■■■■■■■■■■■                57% | ETA:  6s
+Reading counts ■■■■■■■■■■■■■■■■■■                57% | ETA:  5s
 
 Reading counts ■■■■■■■■■■■■■■■■■■■■■■            71% | ETA:  4s
 
@@ -417,27 +444,27 @@ Reading counts ■■■■■■■■■■■■■■■■■■■■■�
 #> ℹ Compiling Experiment.
 
 pseudobulk_counts
-#> # A SingleCellExperiment-tibble abstraction: 139 × 43
-#> # [90mFeatures=15888 | Cells=139 | Assays=counts[0m
-#>    .cell           dataset_id sample_id sample_ experiment___ run_from_cell_id sample_heuristic age_days tissue_groups cell_type_unified_en…¹ sample_chunk cell_chunk
-#>    <chr>           <chr>      <chr>     <chr>   <chr>         <chr>            <chr>               <int> <chr>         <chr>                         <int>      <int>
-#>  1 2e8c9911c9bfbf… 0ba16f4b-… 2e8c9911… 2e8c99… ""            <NA>             HDBR15279,HDBR1…       NA respiratory … cd14 mono                         1          1
-#>  2 0d874636bc714a… 1e6a6ef9-… 0d874636… 0d8746… ""            <NA>             Leader_Merad_20…    29930 respiratory … monocytic                         1          5
-#>  3 0d874636bc714a… 1e6a6ef9-… 0d874636… 0d8746… ""            <NA>             Leader_Merad_20…    29930 respiratory … cd14 mono                         1          5
-#>  4 0d874636bc714a… 1e6a6ef9-… 0d874636… 0d8746… ""            <NA>             Leader_Merad_20…    29930 respiratory … cd16 mono                         1          5
-#>  5 0d874636bc714a… 1e6a6ef9-… 0d874636… 0d8746… ""            <NA>             Leader_Merad_20…    29930 respiratory … macrophage                        1          5
-#>  6 0d874636bc714a… 1e6a6ef9-… 0d874636… 0d8746… ""            <NA>             Leader_Merad_20…    29930 respiratory … other                             1          5
-#>  7 11721339cb1dfc… 1e6a6ef9-… 11721339… 117213… ""            <NA>             Leader_Merad_20…    26645 respiratory … monocytic                         1          7
-#>  8 11721339cb1dfc… 1e6a6ef9-… 11721339… 117213… ""            <NA>             Leader_Merad_20…    26645 respiratory … cd14 mono                         1          7
-#>  9 f71af64a552d45… 1e6a6ef9-… f71af64a… f71af6… ""            <NA>             Leader_Merad_20…    27010 respiratory … monocytic                         1          6
-#> 10 f71af64a552d45… 1e6a6ef9-… f71af64a… f71af6… ""            <NA>             Leader_Merad_20…    27010 respiratory … cd14 mono                         1          6
-#> # ℹ 129 more rows
+#> # A SingleCellExperiment-tibble abstraction: 146 × 46
+#> # [90mFeatures=15888 | Cells=146 | Assays=counts[0m
+#>    .cell  sample_id cell_type_unified_en…¹ dataset_id donor_id age_days tissue_groups empty_droplet is_immune high_mitochondrion
+#>    <chr>  <chr>     <chr>                  <chr>      <chr>       <int> <chr>         <lgl>         <lgl>     <lgl>             
+#>  1 2e8c9… 2e8c9911… cd14 mono              0ba16f4b-… HDBR152…       NA respiratory … FALSE         TRUE      FALSE             
+#>  2 f71af… f71af64a… monocytic              1e6a6ef9-… Leader_…    27010 respiratory … FALSE         TRUE      FALSE             
+#>  3 f71af… f71af64a… cd14 mono              1e6a6ef9-… Leader_…    27010 respiratory … FALSE         TRUE      FALSE             
+#>  4 f71af… f71af64a… cd8 tem                1e6a6ef9-… Leader_…    27010 respiratory … FALSE         TRUE      FALSE             
+#>  5 11721… 11721339… monocytic              1e6a6ef9-… Leader_…    26645 respiratory … FALSE         TRUE      FALSE             
+#>  6 11721… 11721339… cd14 mono              1e6a6ef9-… Leader_…    26645 respiratory … FALSE         TRUE      FALSE             
+#>  7 0d874… 0d874636… cd14 mono              1e6a6ef9-… Leader_…    29930 respiratory … FALSE         TRUE      FALSE             
+#>  8 0d874… 0d874636… cd16 mono              1e6a6ef9-… Leader_…    29930 respiratory … FALSE         TRUE      FALSE             
+#>  9 0d874… 0d874636… macrophage             1e6a6ef9-… Leader_…    29930 respiratory … FALSE         TRUE      FALSE             
+#> 10 0d874… 0d874636… monocytic              1e6a6ef9-… Leader_…    29930 respiratory … FALSE         TRUE      FALSE             
+#> # ℹ 136 more rows
 #> # ℹ abbreviated name: ¹​cell_type_unified_ensemble
-#> # ℹ 31 more variables: sample_pseudobulk_chunk <int>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>,
-#> #   inverse_transform <chr>, ethnicity_flagging_score <dbl>, low_confidence_ethnicity <chr>, .aggregated_cells <int>, imputed_ethnicity <chr>, atlas_id <chr>,
-#> #   dataset_version_id <chr>, collection_id <chr>, cell_count <int>, citation <chr>, default_embedding <chr>, explorer_url <chr>, feature_count <int>,
-#> #   mean_genes_per_cell <dbl>, primary_cell_count <int>, schema_version <chr>, title <chr>, tombstone <lgl>, x_approximate_distribution <chr>, published_at <date>,
-#> #   revised_at <date>, tissue <chr>, self_reported_ethnicity <chr>, assay <chr>, disease <chr>, sex <chr>, sample_identifier <chr>
+#> # ℹ 36 more variables: alive <lgl>, scDblFinder.class <chr>, file_id_cellNexus_single_cell <chr>,
+#> #   file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>, inverse_transform <chr>,
+#> #   cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>, low_confidence_ethnicity <chr>, .aggregated_cells <int>,
+#> #   imputed_ethnicity <chr>, atlas_id <chr>, dataset_version_id <chr>, collection_id <chr>, cell_count <int>, citation <chr>,
+#> #   default_embedding <chr>, explorer_url <chr>, feature_count <int>, mean_genes_per_cell <dbl>, primary_cell_count <int>, …
 ```
 
 ## Download cell communication metadata
@@ -465,15 +492,16 @@ case.
 get_cell_communication_strength(cloud_metadata = get_metadata_url("cellNexus_lr_signaling_pathway_strength_DEMO.parquet"))
 #> # Source:   SQL [?? x 16]
 #> # Database: DuckDB 1.4.3 [unknown@Linux 5.14.0-570.123.1.el9_6.x86_64:R 4.5.3/:memory:]
-#>   source    target ligand receptor   lr_prob lr_pval interaction_name    interaction_name_2      pathway_name annotation evidence pathway_prob pathway_pval sample_id
-#>   <chr>     <chr>  <chr>  <chr>        <dbl>   <dbl> <chr>               <chr>                   <chr>        <chr>      <chr>           <dbl>        <dbl> <chr>    
-#> 1 b         b      TGFB1  TGFbR1_R2 0.000116    1    TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR2) TGFb         Secreted … KEGG: h…     0.000420        1     b290d7ef…
-#> 2 b memory  b      TGFB1  TGFbR1_R2 0.000865    1    TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR2) TGFb         Secreted … KEGG: h…     0.00185         1     b290d7ef…
-#> 3 b naive   b      TGFB1  TGFbR1_R2 0.000696    0.99 TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR2) TGFb         Secreted … KEGG: h…     0.00146         0.994 b290d7ef…
-#> 4 cd14 mono b      TGFB1  TGFbR1_R2 0.00240     0.81 TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR2) TGFb         Secreted … KEGG: h…     0.00472         0.924 b290d7ef…
-#> 5 cd4 naive b      TGFB1  TGFbR1_R2 0.000957    1    TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR2) TGFb         Secreted … KEGG: h…     0.00201         0.998 b290d7ef…
-#> 6 cd4 tem   b      TGFB1  TGFbR1_R2 0.00242     0.76 TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR2) TGFb         Secreted … KEGG: h…     0.00467         0.797 b290d7ef…
-#> # ℹ 2 more variables: interaction_count <dbl>, interaction_weight <dbl>
+#>   source    target ligand receptor   lr_prob lr_pval interaction_name    interaction_name_2     pathway_name annotation evidence
+#>   <chr>     <chr>  <chr>  <chr>        <dbl>   <dbl> <chr>               <chr>                  <chr>        <chr>      <chr>   
+#> 1 b         b      TGFB1  TGFbR1_R2 0.000116    1    TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR… TGFb         Secreted … KEGG: h…
+#> 2 b memory  b      TGFB1  TGFbR1_R2 0.000865    1    TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR… TGFb         Secreted … KEGG: h…
+#> 3 b naive   b      TGFB1  TGFbR1_R2 0.000696    0.99 TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR… TGFb         Secreted … KEGG: h…
+#> 4 cd14 mono b      TGFB1  TGFbR1_R2 0.00240     0.81 TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR… TGFb         Secreted … KEGG: h…
+#> 5 cd4 naive b      TGFB1  TGFbR1_R2 0.000957    1    TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR… TGFb         Secreted … KEGG: h…
+#> 6 cd4 tem   b      TGFB1  TGFbR1_R2 0.00242     0.76 TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR… TGFb         Secreted … KEGG: h…
+#> # ℹ 5 more variables: pathway_prob <dbl>, pathway_pval <dbl>, sample_id <chr>, interaction_count <dbl>,
+#> #   interaction_weight <dbl>
 ```
 
 ### Extract only a subset of genes
@@ -496,15 +524,15 @@ single_cell_cpm <-
 #> ℹ Synchronising files
 #> ℹ Reading files.
 #> 
-Reading cpm ■■■■■■■                           20% | ETA:  5s
+Reading cpm ■■■■■■■                           20% | ETA:  4s
 
 Reading cpm ■■■■■■■■■■                        30% | ETA:  4s
 
-Reading cpm ■■■■■■■■■■■■■                     40% | ETA:  4s
+Reading cpm ■■■■■■■■■■■■■                     40% | ETA:  3s
 
 Reading cpm ■■■■■■■■■■■■■■■■                  50% | ETA:  3s
 
-Reading cpm ■■■■■■■■■■■■■■■■■■■               60% | ETA:  3s
+Reading cpm ■■■■■■■■■■■■■■■■■■■               60% | ETA:  2s
 
 Reading cpm ■■■■■■■■■■■■■■■■■■■■■■            70% | ETA:  2s
 
@@ -516,27 +544,27 @@ Reading cpm ■■■■■■■■■■■■■■■■■■■■■■�
 ℹ Compiling Experiment.
 
 single_cell_cpm
-#> # A SingleCellExperiment-tibble abstraction: 2,806 × 60
-#> # [90mFeatures=1 | Cells=2806 | Assays=cpm[0m
-#>    .cell observation_joinid dataset_id     sample_id sample_ experiment___ run_from_cell_id sample_heuristic age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA
-#>    <chr> <chr>              <chr>          <chr>     <chr>   <chr>         <chr>            <chr>               <int> <chr>                          <int>      <dbl>
-#>  1 80_1  zz-!e5_XAo         842c6f5d-4a94… 1de3f3ba… 1de3f3… ""            <NA>             7fabaf1c-52fd-4…    14600 breast                          1749      10.8 
-#>  2 81_1  -mb&DWckf(         842c6f5d-4a94… 1de3f3ba… 1de3f3… ""            <NA>             7fabaf1c-52fd-4…    14600 breast                          1993      12.4 
-#>  3 72_1  8wGs7JgUjj         842c6f5d-4a94… 6b194412… 6b1944… ""            <NA>             b3ff1aad-40fd-4…    14600 breast                          2548      13.1 
-#>  4 75_1  F9G7A+GgjA         842c6f5d-4a94… db5a69ed… db5a69… ""            <NA>             49beb83c-66a1-4…    14600 breast                          1291      10.2 
-#>  5 73_1  z_=CTOs4{z         842c6f5d-4a94… 4b5e66fa… 4b5e66… ""            <NA>             04983012-bb56-4…    14600 breast                          2866      10.3 
-#>  6 74_1  fNzorxA`Mf         842c6f5d-4a94… 4b5e66fa… 4b5e66… ""            <NA>             04983012-bb56-4…    14600 breast                          1942       7.58
-#>  7 76_1  bTlx!HK=oS         842c6f5d-4a94… 52ab9222… 52ab92… ""            <NA>             7ce86149-8906-4…    14600 breast                          1671       9.65
-#>  8 77_1  E4g5+)v;AV         842c6f5d-4a94… 52ab9222… 52ab92… ""            <NA>             7ce86149-8906-4…    14600 breast                          2340      11.9 
-#>  9 78_1  +q?29B%2nH         842c6f5d-4a94… 52ab9222… 52ab92… ""            <NA>             7ce86149-8906-4…    14600 breast                          1714      13.2 
-#> 10 79_1  zuJ#MBMWy;         842c6f5d-4a94… 52ab9222… 52ab92… ""            <NA>             7ce86149-8906-4…    14600 breast                          1506      12.3 
+#> # A SingleCellExperiment-tibble abstraction: 2,806 × 54
+#> # [90mFeatures=1 | Cells=2806 | Assays=cpm[0m
+#>    .cell observation_joinid dataset_id sample_id donor_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA empty_droplet
+#>    <chr> <chr>              <chr>      <chr>     <chr>       <int> <chr>                          <int>      <dbl> <lgl>        
+#>  1 76_1  bTlx!HK=oS         842c6f5d-… 52ab9222… P58         14600 breast                          1671       9.65 FALSE        
+#>  2 77_1  E4g5+)v;AV         842c6f5d-… 52ab9222… P58         14600 breast                          2340      11.9  FALSE        
+#>  3 78_1  +q?29B%2nH         842c6f5d-… 52ab9222… P58         14600 breast                          1714      13.2  FALSE        
+#>  4 79_1  zuJ#MBMWy;         842c6f5d-… 52ab9222… P58         14600 breast                          1506      12.3  FALSE        
+#>  5 72_1  8wGs7JgUjj         842c6f5d-… 6b194412… P39         14600 breast                          2548      13.1  FALSE        
+#>  6 75_1  F9G7A+GgjA         842c6f5d-… db5a69ed… P40         14600 breast                          1291      10.2  FALSE        
+#>  7 80_1  zz-!e5_XAo         842c6f5d-… 1de3f3ba… P58         14600 breast                          1749      10.8  FALSE        
+#>  8 81_1  -mb&DWckf(         842c6f5d-… 1de3f3ba… P58         14600 breast                          1993      12.4  FALSE        
+#>  9 73_1  z_=CTOs4{z         842c6f5d-… 4b5e66fa… P39         14600 breast                          2866      10.3  FALSE        
+#> 10 74_1  fNzorxA`Mf         842c6f5d-… 4b5e66fa… P39         14600 breast                          1942       7.58 FALSE        
 #> # ℹ 2,796 more rows
 #> # ℹ abbreviated name: ¹​nFeature_expressed_in_sample
-#> # ℹ 48 more variables: empty_droplet <lgl>, cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>, subsets_Ribo_percent <int>,
-#> #   high_mitochondrion <lgl>, high_ribosome <lgl>, scDblFinder.class <chr>, sample_chunk <int>, cell_chunk <int>, sample_pseudobulk_chunk <int>,
-#> #   file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>, inverse_transform <chr>,
-#> #   alive <lgl>, cell_annotation_blueprint_singler <chr>, cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>,
-#> #   low_confidence_ethnicity <chr>, .aggregated_cells <int>, imputed_ethnicity <chr>, atlas_id <chr>, dataset_version_id <chr>, collection_id <chr>, …
+#> # ℹ 44 more variables: cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>,
+#> #   subsets_Ribo_percent <int>, high_mitochondrion <lgl>, high_ribosome <lgl>, alive <lgl>, scDblFinder.class <chr>,
+#> #   file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>,
+#> #   nfeature_expressed_thresh <dbl>, inverse_transform <chr>, cell_annotation_blueprint_singler <chr>,
+#> #   cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>, …
 ```
 
 ### Extract the counts as a Seurat object
@@ -559,19 +587,19 @@ seurat_counts <-
 #> ℹ Synchronising files
 #> ℹ Reading files.
 #> 
-Reading counts ■■■■■■■                           20% | ETA:  5s
+Reading counts ■■■■■■■                           20% | ETA:  4s
 
-Reading counts ■■■■■■■■■■                        30% | ETA:  5s
+Reading counts ■■■■■■■■■■                        30% | ETA:  4s
 
-Reading counts ■■■■■■■■■■■■■                     40% | ETA:  4s
+Reading counts ■■■■■■■■■■■■■                     40% | ETA:  3s
 
 Reading counts ■■■■■■■■■■■■■■■■                  50% | ETA:  3s
 
-Reading counts ■■■■■■■■■■■■■■■■■■■               60% | ETA:  3s
+Reading counts ■■■■■■■■■■■■■■■■■■■               60% | ETA:  2s
 
-Reading counts ■■■■■■■■■■■■■■■■■■■■■■            70% | ETA:  3s
+Reading counts ■■■■■■■■■■■■■■■■■■■■■■            70% | ETA:  2s
 
-Reading counts ■■■■■■■■■■■■■■■■■■■■■■■■■         80% | ETA:  2s
+Reading counts ■■■■■■■■■■■■■■■■■■■■■■■■■         80% | ETA:  1s
 
 Reading counts ■■■■■■■■■■■■■■■■■■■■■■■■■■■■      90% | ETA:  1s
 
@@ -579,10 +607,27 @@ Reading counts ■■■■■■■■■■■■■■■■■■■■■�
 ℹ Compiling Experiment.
 
 seurat_counts
-#> An object of class Seurat 
-#> 33145 features across 2806 samples within 1 assay 
-#> Active assay: originalexp (33145 features, 0 variable features)
-#>  2 layers present: counts, data
+#> # A Seurat-tibble abstraction: 2,806 × 59
+#> # [90mFeatures=33145 | Cells=2806 | Active assay=counts | Assays=counts[0m
+#>    .cell orig.ident    nCount_originalexp nFeature_originalexp observation_joinid dataset_id         sample_id donor_id age_days
+#>    <chr> <fct>                      <dbl>                <int> <chr>              <chr>              <chr>     <chr>       <int>
+#>  1 73_1  SeuratProject               14.1                 2958 z_=CTOs4{z         842c6f5d-4a94-4ee… 4b5e66fa… P39         14600
+#>  2 74_1  SeuratProject               14.2                 2035 fNzorxA`Mf         842c6f5d-4a94-4ee… 4b5e66fa… P39         14600
+#>  3 76_1  SeuratProject               15.5                 1759 bTlx!HK=oS         842c6f5d-4a94-4ee… 52ab9222… P58         14600
+#>  4 77_1  SeuratProject               15.4                 2434 E4g5+)v;AV         842c6f5d-4a94-4ee… 52ab9222… P58         14600
+#>  5 78_1  SeuratProject               15.3                 1798 +q?29B%2nH         842c6f5d-4a94-4ee… 52ab9222… P58         14600
+#>  6 79_1  SeuratProject               15.4                 1595 zuJ#MBMWy;         842c6f5d-4a94-4ee… 52ab9222… P58         14600
+#>  7 1_1   SeuratProject               15.3                 3493 I8a42<8st4         842c6f5d-4a94-4ee… 184fa234… P65         14600
+#>  8 80_1  SeuratProject               15.5                 1837 zz-!e5_XAo         842c6f5d-4a94-4ee… 1de3f3ba… P58         14600
+#>  9 81_1  SeuratProject               15.2                 2082 -mb&DWckf(         842c6f5d-4a94-4ee… 1de3f3ba… P58         14600
+#> 10 72_1  SeuratProject               18.0                 2642 8wGs7JgUjj         842c6f5d-4a94-4ee… 6b194412… P39         14600
+#> # ℹ 2,796 more rows
+#> # ℹ 50 more variables: tissue_groups <chr>, nFeature_expressed_in_sample <int>, nCount_RNA <dbl>, empty_droplet <lgl>,
+#> #   cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>, subsets_Ribo_percent <int>,
+#> #   high_mitochondrion <lgl>, high_ribosome <lgl>, alive <lgl>, scDblFinder.class <chr>, file_id_cellNexus_single_cell <chr>,
+#> #   file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>, inverse_transform <chr>,
+#> #   cell_annotation_blueprint_singler <chr>, cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>,
+#> #   ethnicity_flagging_score <dbl>, low_confidence_ethnicity <chr>, .aggregated_cells <int>, imputed_ethnicity <chr>, …
 ```
 
 By default, data is downloaded to `get_default_cache_dir()` output. If
@@ -808,25 +853,28 @@ get_metadata(
   dplyr::filter(file_id_cellNexus_single_cell %in% c(file_id_from_cloud, file_id_local)) |>
   dplyr::select(cell_id, sample_id, dataset_id, cell_type_unified_ensemble, atlas_id, file_id_cellNexus_single_cell) |>
   get_single_cell_experiment(cache_directory = local_cache)
+#> ℹ Downloading 1 file, totalling 0 GB
+#> ℹ Downloading https://object-store.rc.nectar.org.au/v1/AUTH_06d6e008e3e642da99d806ba3ea629c5/cellNexus-metadata/sample_hca2024_v2.3.2.parquet to /vast/scratch/users/shen.m/tmp/RtmpE4YcCe/sample_hca2024_v2.3.2.parquet
 #> ℹ Realising metadata.
 #> ℹ Synchronising files
 #> ℹ Reading files.
 #> ℹ Compiling Experiment.
 #> # A SingleCellExperiment-tibble abstraction: 500 × 7
-#> # [90mFeatures=13132 | Cells=500 | Assays=counts[0m
-#>    .cell            sample_id dataset_id cell_type_unified_ensemble atlas_id             file_id_cellNexus_single_cell         original_cell_
-#>    <chr>            <chr>     <chr>      <chr>                      <chr>                <chr>                                 <chr>         
-#>  1 AAACATACAACCAC_1 pbmc3k    pbmc3k     Memory CD4 T               cellxgene/03-10-2025 67e196a3c4e145151fc9e06c200e2f7f.h5ad AAACATACAACCAC
-#>  2 AAACATTGAGCTAC_1 pbmc3k    pbmc3k     B                          cellxgene/03-10-2025 67e196a3c4e145151fc9e06c200e2f7f.h5ad AAACATTGAGCTAC
-#>  3 AAACATTGATCAGC_1 pbmc3k    pbmc3k     Memory CD4 T               cellxgene/03-10-2025 67e196a3c4e145151fc9e06c200e2f7f.h5ad AAACATTGATCAGC
-#>  4 AAACCGTGCTTCCG_1 pbmc3k    pbmc3k     CD14+ Mono                 cellxgene/03-10-2025 67e196a3c4e145151fc9e06c200e2f7f.h5ad AAACCGTGCTTCCG
-#>  5 AAACCGTGTATGCG_1 pbmc3k    pbmc3k     NK                         cellxgene/03-10-2025 67e196a3c4e145151fc9e06c200e2f7f.h5ad AAACCGTGTATGCG
-#>  6 AAACGCACTGGTAC_1 pbmc3k    pbmc3k     Memory CD4 T               cellxgene/03-10-2025 67e196a3c4e145151fc9e06c200e2f7f.h5ad AAACGCACTGGTAC
-#>  7 AAACGCTGACCAGT_1 pbmc3k    pbmc3k     CD8 T                      cellxgene/03-10-2025 67e196a3c4e145151fc9e06c200e2f7f.h5ad AAACGCTGACCAGT
-#>  8 AAACGCTGGTTCTT_1 pbmc3k    pbmc3k     CD8 T                      cellxgene/03-10-2025 67e196a3c4e145151fc9e06c200e2f7f.h5ad AAACGCTGGTTCTT
-#>  9 AAACGCTGTAGCCA_1 pbmc3k    pbmc3k     Naive CD4 T                cellxgene/03-10-2025 67e196a3c4e145151fc9e06c200e2f7f.h5ad AAACGCTGTAGCCA
-#> 10 AAACGCTGTTTCTG_1 pbmc3k    pbmc3k     FCGR3A+ Mono               cellxgene/03-10-2025 67e196a3c4e145151fc9e06c200e2f7f.h5ad AAACGCTGTTTCTG
+#> # [90mFeatures=13132 | Cells=500 | Assays=counts[0m
+#>    .cell            sample_id dataset_id cell_type_unified_ensemble atlas_id             file_id_cellNexus_sing…¹ original_cell_
+#>    <chr>            <chr>     <chr>      <chr>                      <chr>                <chr>                    <chr>         
+#>  1 AAACATACAACCAC_1 pbmc3k    pbmc3k     Memory CD4 T               cellxgene/03-10-2025 67e196a3c4e145151fc9e06… AAACATACAACCAC
+#>  2 AAACATTGAGCTAC_1 pbmc3k    pbmc3k     B                          cellxgene/03-10-2025 67e196a3c4e145151fc9e06… AAACATTGAGCTAC
+#>  3 AAACATTGATCAGC_1 pbmc3k    pbmc3k     Memory CD4 T               cellxgene/03-10-2025 67e196a3c4e145151fc9e06… AAACATTGATCAGC
+#>  4 AAACCGTGCTTCCG_1 pbmc3k    pbmc3k     CD14+ Mono                 cellxgene/03-10-2025 67e196a3c4e145151fc9e06… AAACCGTGCTTCCG
+#>  5 AAACCGTGTATGCG_1 pbmc3k    pbmc3k     NK                         cellxgene/03-10-2025 67e196a3c4e145151fc9e06… AAACCGTGTATGCG
+#>  6 AAACGCACTGGTAC_1 pbmc3k    pbmc3k     Memory CD4 T               cellxgene/03-10-2025 67e196a3c4e145151fc9e06… AAACGCACTGGTAC
+#>  7 AAACGCTGACCAGT_1 pbmc3k    pbmc3k     CD8 T                      cellxgene/03-10-2025 67e196a3c4e145151fc9e06… AAACGCTGACCAGT
+#>  8 AAACGCTGGTTCTT_1 pbmc3k    pbmc3k     CD8 T                      cellxgene/03-10-2025 67e196a3c4e145151fc9e06… AAACGCTGGTTCTT
+#>  9 AAACGCTGTAGCCA_1 pbmc3k    pbmc3k     Naive CD4 T                cellxgene/03-10-2025 67e196a3c4e145151fc9e06… AAACGCTGTAGCCA
+#> 10 AAACGCTGTTTCTG_1 pbmc3k    pbmc3k     FCGR3A+ Mono               cellxgene/03-10-2025 67e196a3c4e145151fc9e06… AAACGCTGTTTCTG
 #> # ℹ 490 more rows
+#> # ℹ abbreviated name: ¹​file_id_cellNexus_single_cell
 ```
 
 # Cell metadata
@@ -872,9 +920,9 @@ sessionInfo()
 #> LAPACK: /stornext/System/data/software/rhel/9/base/tools/R/4.5.3/lib64/R/lib/libRlapack.so;  LAPACK version 3.12.1
 #> 
 #> locale:
-#>  [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C               LC_TIME=en_US.UTF-8        LC_COLLATE=en_US.UTF-8     LC_MONETARY=en_US.UTF-8   
-#>  [6] LC_MESSAGES=en_US.UTF-8    LC_PAPER=en_US.UTF-8       LC_NAME=C                  LC_ADDRESS=C               LC_TELEPHONE=C            
-#> [11] LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C       
+#>  [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C               LC_TIME=en_US.UTF-8        LC_COLLATE=en_US.UTF-8    
+#>  [5] LC_MONETARY=en_US.UTF-8    LC_MESSAGES=en_US.UTF-8    LC_PAPER=en_US.UTF-8       LC_NAME=C                 
+#>  [9] LC_ADDRESS=C               LC_TELEPHONE=C             LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C       
 #> 
 #> time zone: Australia/Melbourne
 #> tzcode source: system (glibc)
@@ -883,47 +931,102 @@ sessionInfo()
 #> [1] stats4    stats     graphics  grDevices utils     datasets  methods   base     
 #> 
 #> other attached packages:
-#>  [1] BiocStyle_2.38.0            RcppSpdlog_0.0.28           ggplot2_4.0.2               SummarizedExperiment_1.40.0 Biobase_2.70.0             
-#>  [6] GenomicRanges_1.62.1        Seqinfo_1.0.0               IRanges_2.44.0              S4Vectors_0.49.1-1          BiocGenerics_0.56.0        
-#> [11] generics_0.1.4              MatrixGenerics_1.22.0       matrixStats_1.5.0           shiny_1.13.0                anndataR_1.0.2             
-#> [16] cellNexus_0.99.27           testthat_3.3.2              dplyr_1.2.1                
+#>  [1] cellNexus_0.99.30               RcppSpdlog_0.0.28               purrr_1.2.2                    
+#>  [4] HPCell_0.6.0                    ggplot2_4.0.2                   tidyr_1.3.2                    
+#>  [7] tidySingleCellExperiment_1.20.1 ttservice_0.5.3                 SingleCellExperiment_1.32.0    
+#> [10] anndataR_1.3.1                  arrow_23.0.1.2                  SummarizedExperiment_1.40.0    
+#> [13] Biobase_2.70.0                  GenomicRanges_1.62.1            Seqinfo_1.0.0                  
+#> [16] IRanges_2.44.0                  S4Vectors_0.49.1-1              BiocGenerics_0.56.0            
+#> [19] generics_0.1.4                  MatrixGenerics_1.22.0           matrixStats_1.5.0              
+#> [22] dplyr_1.2.1                    
 #> 
 #> loaded via a namespace (and not attached):
-#>   [1] fs_2.0.1                        spatstat.sparse_3.1-0           fontawesome_0.5.3               devtools_2.5.0                  httr_1.4.8                     
-#>   [6] RColorBrewer_1.1-3              tools_4.5.3                     sctransform_0.4.3               backports_1.5.1                 utf8_1.2.6                     
-#>  [11] R6_2.6.1                        DT_0.34.0                       HDF5Array_1.38.0                lazyeval_0.2.3                  uwot_0.2.4                     
-#>  [16] rhdf5filters_1.22.0             withr_3.0.2                     sp_2.2-1                        gridExtra_2.3                   nanoarrow_0.8.0                
-#>  [21] progressr_0.19.0                cli_3.6.6                       spatstat.explore_3.8-0          fastDummies_1.7.5               sass_0.4.10                    
-#>  [26] Seurat_5.5.0.9002               arrow_23.0.1.2                  S7_0.2.1-1                      spatstat.data_3.1-9             ggridges_0.5.7                 
-#>  [31] pbapply_1.7-4                   commonmark_2.0.0                R.utils_2.13.0                  parallelly_1.46.1               sessioninfo_1.2.3              
-#>  [36] rstudioapi_0.18.0               ica_1.0-3                       spatstat.random_3.4-5           Matrix_1.7-4                    fansi_1.0.7                    
-#>  [41] waldo_0.6.2                     rclipboard_0.2.1                abind_1.4-8                     R.methodsS3_1.8.2               lifecycle_1.0.5                
-#>  [46] yaml_2.3.12                     rhdf5_2.54.1                    SparseArray_1.10.10             Rtsne_0.17                      grid_4.5.3                     
-#>  [51] blob_1.3.0                      promises_1.5.0                  dir.expiry_1.18.0               miniUI_0.1.2                    lattice_0.22-9                 
-#>  [56] cowplot_1.2.0                   pillar_1.11.1                   knitr_1.51                      future.apply_1.20.2             codetools_0.2-20               
-#>  [61] glue_1.8.0                      tiledb_0.33.1                   spatstat.univar_3.1-7           data.table_1.18.2.1             tidySingleCellExperiment_1.20.1
-#>  [66] vctrs_0.7.3                     png_0.1-9                       spam_2.11-3                     gtable_0.3.6                    aws.s3_0.3.22                  
-#>  [71] assertthat_0.2.1                cachem_1.1.0                    xfun_0.57                       S4Arrays_1.10.1                 mime_0.13                      
-#>  [76] rsconnect_1.8.0                 survival_3.8-6                  SingleCellExperiment_1.32.0     ellipsis_0.3.3                  fitdistrplus_1.2-6             
-#>  [81] ROCR_1.0-12                     tiledbsoma_2.1.2                nlme_3.1-168                    RcppCCTZ_0.2.14                 usethis_3.2.1                  
-#>  [86] bit64_4.6.0-1                   filelock_1.0.3                  RcppAnnoy_0.0.23                GenomeInfoDb_1.46.2             rprojroot_2.1.1                
-#>  [91] R.cache_0.17.0                  bslib_0.10.0                    irlba_2.3.7                     KernSmooth_2.23-26              otel_0.2.0                     
-#>  [96] DBI_1.3.0                       zellkonverter_1.20.1            duckdb_1.4.3                    tidyselect_1.2.1                cellxgene.census_1.16.1        
-#> [101] bit_4.6.0                       compiler_4.5.3                  curl_7.0.0                      rjsoncons_1.3.2                 h5mread_1.2.1                  
-#> [106] xml2_1.5.2                      nanotime_0.3.13                 desc_1.4.3                      DelayedArray_0.36.1             plotly_4.12.0                  
-#> [111] bookdown_0.46                   checkmate_2.3.4                 scales_1.4.0                    lmtest_0.9-40                   spdl_0.0.5                     
-#> [116] stringr_1.6.0                   digest_0.6.39                   goftest_1.2-3                   spatstat.utils_3.2-2            rmarkdown_2.31                 
-#> [121] basilisk_1.22.0                 XVector_0.50.0                  htmltools_0.5.9                 pkgconfig_2.0.3                 base64enc_0.1-6                
-#> [126] dbplyr_2.5.2                    fastmap_1.2.0                   rlang_1.2.0                     htmlwidgets_1.6.4               UCSC.utils_1.6.1               
-#> [131] farver_2.1.2                    jquerylib_0.1.4                 zoo_1.8-15                      jsonlite_2.0.0                  R.oo_1.27.1                    
-#> [136] magrittr_2.0.5                  dotCall64_1.2                   patchwork_1.3.2                 Rhdf5lib_1.32.0                 Rcpp_1.1.1-1                   
-#> [141] reticulate_1.46.0               stringi_1.8.7                   brio_1.1.5                      MASS_7.3-65                     plyr_1.8.9                     
-#> [146] pkgbuild_1.4.8                  parallel_4.5.3                  listenv_0.10.1                  ggrepel_0.9.8                   forcats_1.0.1                  
-#> [151] deldir_2.0-4                    splines_4.5.3                   tensor_1.5.1                    igraph_2.2.3                    cellxgenedp_1.14.0             
-#> [156] spatstat.geom_3.7-3             RcppHNSW_0.6.0                  reshape2_1.4.5                  pkgload_1.5.1                   ttservice_0.5.3                
-#> [161] evaluate_1.0.5                  SeuratObject_5.4.0              BiocManager_1.30.27             httpuv_1.6.17                   RANN_2.6.2                     
-#> [166] tidyr_1.3.2                     purrr_1.2.2                     polyclip_1.10-7                 future_1.70.0                   scattermore_1.2                
-#> [171] xtable_1.8-8                    RSpectra_0.16-2                 roxygen2_7.3.3                  later_1.4.8                     viridisLite_0.4.3              
-#> [176] tibble_3.3.1                    memoise_2.0.1                   aws.signature_0.6.0             cluster_2.1.8.2                 shinyWidgets_0.9.1             
-#> [181] globals_0.19.1
+#>   [1] igraph_2.2.3                    ica_1.0-3                       plotly_4.12.0                  
+#>   [4] SingleR_2.12.0                  scater_1.38.1                   devtools_2.5.0                 
+#>   [7] tidyselect_1.2.1                bit_4.6.0                       lattice_0.22-9                 
+#>  [10] rjson_0.2.21                    blob_1.3.0                      stringr_1.6.0                  
+#>  [13] S4Arrays_1.10.1                 rclipboard_0.2.1                parallel_4.5.3                 
+#>  [16] png_0.1-9                       cli_3.6.6                       ProtGenerics_1.42.0            
+#>  [19] askpass_1.2.1                   openssl_2.4.2                   goftest_1.2-3                  
+#>  [22] BiocIO_1.20.0                   bluster_1.20.0                  BiocNeighbors_2.4.0            
+#>  [25] tarchetypes_0.14.1              uwot_0.2.4                      curl_7.0.0                     
+#>  [28] mime_0.13                       evaluate_1.0.5                  stringi_1.8.7                  
+#>  [31] ids_1.0.1                       backports_1.5.1                 desc_1.4.3                     
+#>  [34] XML_3.99-0.23                   httpuv_1.6.17                   AnnotationDbi_1.72.0           
+#>  [37] magrittr_2.0.5                  rappdirs_0.3.4                  splines_4.5.3                  
+#>  [40] nanonext_1.8.2                  aws.signature_0.6.0             DT_0.34.0                      
+#>  [43] sctransform_0.4.3               ggbeeswarm_0.7.3                sessioninfo_1.2.3              
+#>  [46] DBI_1.3.0                       HDF5Array_1.38.0                jquerylib_0.1.4                
+#>  [49] withr_3.0.2                     reformulas_0.4.4                rprojroot_2.1.1                
+#>  [52] xgboost_3.2.1.1                 tidySummarizedExperiment_1.20.1 lmtest_0.9-40                  
+#>  [55] brio_1.1.5                      BiocManager_1.30.27             rtracklayer_1.70.1             
+#>  [58] duckdb_1.4.3                    htmlwidgets_1.6.4               fs_2.0.1                       
+#>  [61] biomaRt_2.66.2                  ggrepel_0.9.8                   SparseArray_1.10.10            
+#>  [64] tidyseurat_0.8.10               h5mread_1.2.1                   reticulate_1.46.0              
+#>  [67] zoo_1.8-15                      tiledbsoma_2.1.2                XVector_0.50.0                 
+#>  [70] knitr_1.51                      RcppCCTZ_0.2.14                 UCSC.utils_1.6.1               
+#>  [73] secretbase_1.2.1                fansi_1.0.7                     patchwork_1.3.2                
+#>  [76] pak_0.11.1                      grid_4.5.3                      data.table_1.18.2.1            
+#>  [79] rhdf5_2.54.1                    R.oo_1.27.1                     RSpectra_0.16-2                
+#>  [82] irlba_2.3.7                     tiledb_0.33.1                   commonmark_2.0.0               
+#>  [85] fastDummies_1.7.5               ellipsis_0.3.3                  base64url_1.4                  
+#>  [88] lazyeval_0.2.3                  yaml_2.3.12                     conflicted_1.2.0               
+#>  [91] survival_3.8-6                  scattermore_1.2                 crayon_1.5.3                   
+#>  [94] mirai_2.6.1                     RcppAnnoy_0.0.23                RColorBrewer_1.1-3             
+#>  [97] progressr_0.19.0                later_1.4.8                     ggridges_0.5.7                 
+#> [100] codetools_0.2-20                base64enc_0.1-6                 tidybulk_2.1.0                 
+#> [103] Seurat_5.5.0.9002               KEGGREST_1.50.0                 Rtsne_0.17                     
+#> [106] limma_3.66.0                    Rsamtools_2.26.0                filelock_1.0.3                 
+#> [109] pkgconfig_2.0.3                 xml2_1.5.2                      spatstat.univar_3.1-7          
+#> [112] GenomicAlignments_1.46.0        spatstat.sparse_3.1-0           viridisLite_0.4.3              
+#> [115] xtable_1.8-8                    plyr_1.8.9                      httr_1.4.8                     
+#> [118] rbibutils_2.4.1                 tools_4.5.3                     globals_0.19.1                 
+#> [121] SeuratObject_5.4.0              pkgbuild_1.4.8                  beeswarm_0.4.0                 
+#> [124] checkmate_2.3.4                 nlme_3.1-168                    dbplyr_2.5.2                   
+#> [127] assertthat_0.2.1                lme4_2.0-1                      digest_0.6.39                  
+#> [130] Matrix_1.7-4                    dir.expiry_1.18.0               farver_2.1.2                   
+#> [133] tzdb_0.5.0                      AnnotationFilter_1.34.0         reshape2_1.4.5                 
+#> [136] viridis_0.6.5                   glue_1.8.0                      cachem_1.1.0                   
+#> [139] BiocFileCache_3.0.0             polyclip_1.10-7                 rjsoncons_1.3.2                
+#> [142] Biostrings_2.78.0               parallelly_1.46.1               aws.s3_0.3.22                  
+#> [145] pkgload_1.5.1                   statmod_1.5.1                   here_1.0.2                     
+#> [148] RcppHNSW_0.6.0                  ScaledMatrix_1.18.0             minqa_1.2.8                    
+#> [151] pbapply_1.7-4                   httr2_1.2.2                     job_0.3.1                      
+#> [154] spam_2.11-3                     dqrng_0.4.1                     utf8_1.2.6                     
+#> [157] scDblFinder_1.24.10             basilisk_1.22.0                 crew_1.3.0                     
+#> [160] gridExtra_2.3                   shiny_1.13.0                    R.utils_2.13.0                 
+#> [163] rhdf5filters_1.22.0             RCurl_1.98-1.18                 memoise_2.0.1                  
+#> [166] rmarkdown_2.31                  nanoarrow_0.8.0                 scales_1.4.0                   
+#> [169] R.methodsS3_1.8.2               future_1.70.0                   RANN_2.6.2                     
+#> [172] renv_1.2.1                      spatstat.data_3.1-9             rstudioapi_0.18.0              
+#> [175] cluster_2.1.8.2                 zellkonverter_1.20.1            spatstat.utils_3.2-2           
+#> [178] hms_1.1.4                       fitdistrplus_1.2-6              cowplot_1.2.0                  
+#> [181] rlang_1.2.0                     GenomeInfoDb_1.46.2             crew.cluster_0.4.0             
+#> [184] DelayedMatrixStats_1.32.0       sparseMatrixStats_1.22.0        shinyWidgets_0.9.1             
+#> [187] dotCall64_1.2                   scuttle_1.20.0                  xfun_0.57                      
+#> [190] abind_1.4-8                     spdl_0.0.5                      tibble_3.3.1                   
+#> [193] EnsDb.Hsapiens.v86_2.99.0       Rhdf5lib_1.32.0                 readr_2.2.0                    
+#> [196] bitops_1.0-9                    Rdpack_2.6.6                    ps_1.9.2                       
+#> [199] promises_1.5.0                  RSQLite_2.4.6                   cellxgenedp_1.14.0             
+#> [202] DelayedArray_0.36.1             proxy_0.4-29                    compiler_4.5.3                 
+#> [205] forcats_1.0.1                   prettyunits_1.2.0               boot_1.3-32                    
+#> [208] beachmat_2.26.0                 listenv_0.10.1                  Rcpp_1.1.1-1                   
+#> [211] edgeR_4.8.2                     roxygen2_7.3.3                  BiocSingular_1.26.1            
+#> [214] tensor_1.5.1                    usethis_3.2.1                   MASS_7.3-65                    
+#> [217] progress_1.2.3                  uuid_1.2-2                      BiocParallel_1.44.0            
+#> [220] ggupset_0.4.1                   nanotime_0.3.13                 spatstat.random_3.4-5          
+#> [223] R6_2.6.1                        fastmap_1.2.0                   vipor_0.4.7                    
+#> [226] ensembldb_2.34.0                ROCR_1.0-12                     targets_1.12.0                 
+#> [229] rsvd_1.0.5                      gtable_0.3.6                    KernSmooth_2.23-26             
+#> [232] miniUI_0.1.2                    deldir_2.0-4                    htmltools_0.5.9                
+#> [235] bit64_4.6.0-1                   spatstat.explore_3.8-0          lifecycle_1.0.5                
+#> [238] S7_0.2.1-1                      processx_3.8.7                  nloptr_2.2.1                   
+#> [241] callr_3.7.6                     restfulr_0.0.16                 sass_0.4.10                    
+#> [244] vctrs_0.7.3                     testthat_3.3.2                  rsconnect_1.10.1               
+#> [247] spatstat.geom_3.7-3             scran_1.38.1                    sp_2.2-1                       
+#> [250] future.apply_1.20.2             bslib_0.10.0                    pillar_1.11.1                  
+#> [253] GenomicFeatures_1.62.0          DropletUtils_1.30.0             cellxgene.census_1.16.1        
+#> [256] collections_0.3.12              metapod_1.18.0                  locfit_1.5-9.12                
+#> [259] otel_0.2.0                      BiocStyle_2.38.0                jsonlite_2.0.0                 
+#> [262] cigarillo_1.0.0
 ```

--- a/index.md
+++ b/index.md
@@ -69,8 +69,7 @@ Through harmonisation and curation, `cellNexus` adds columns that are not presen
 | `observation_joinid` | Cell ID join key linking metadata. |
 | `dataset_id` | Primary dataset identifier in the atlas. |
 | `sample_id` | Harmonised sample identifier. |
-| `sample_` | Internal sample subdivision helper. |
-| `sample_heuristic` | Internal sample subdivision helper. |
+| `donor_id` | Donor identifier. |
 | `age_days` | Donor age in days. |
 | `tissue_groups` | Coarse tissue grouping for analysis. |
 | `nFeature_expressed_in_sample` | Number of expressed features per cell. |
@@ -83,9 +82,6 @@ Through harmonisation and curation, `cellNexus` adds columns that are not presen
 | `high_mitochondrion` | TRUE if the cell’s mitochondrial percent exceeds the QC cutoff. |
 | `high_ribosome` | TRUE if the cell’s ribosomal percent exceeds the QC cutoff. |
 | `scDblFinder.class` | Quality-control flag for doublet classification from `scDblFinder`. |
-| `sample_chunk ` | Internal sample subdivision chunks. |
-| `cell_chunk ` | Internal cell subdivision chunks. |
-| `sample_pseudobulk_chunk ` | Internal pseudobulk subdivision chunks. |
 | `file_id_cellNexus_single_cell` | Internal file id for single-cell layers. |
 | `file_id_cellNexus_pseudobulk` | Internal file id for pseudobulk layers. |
 | `count_upper_bound` | Count capping threshold used in transformation. |

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,6 +1,17 @@
 \name{NEWS}
 \title{News for Package \pkg{cellNexus}}
 
+\section{News in version 0.99.31}{
+\itemize{
+    \item Added \code{donor_id} to harmonised metadata, enabling direct donor-level
+    queries across datasets.
+    \item Updated metadata parquet versions to \code{hca2024_v2.3.2}
+    \item Expanded and corrected documentation for metadata columns on website.
+    \item Removed internal columns (\code{sample_},
+    \code{sample_heuristic}, \code{sample_chunk}, \code{cell_chunk}, 
+    \code{sample_pseudobulk_chunk}) from documentation.
+}}
+
 \section{News in version 0.99.30}{
 \itemize{
     \item \code{get_seurat()} now correctly handles multiple assays and non-default

--- a/man/get_metadata.Rd
+++ b/man/get_metadata.Rd
@@ -61,8 +61,7 @@ Field definitions for the CELLxGENE schema follow the
 Through harmonisation and curation we introduced custom columns not present
 in the original CELLxGENE metadata:
 
-\code{cell_count}: Number of cells in a dataset.
-\code{feature_count}: Number of genes in a dataset.
+\code{sample_id}: Sample identifier.
 \code{age_days}: Donor age in days.
 \code{tissue_groups}: Coarse tissue grouping for analysis.
 \code{empty_droplet}: Whether a cell is called an empty droplet from expressed-gene count per sample (default threshold 200; targeted panels may differ).
@@ -71,9 +70,15 @@ in the original CELLxGENE metadata:
 \code{cell_type_unified_ensemble}: Consensus immune identity from Azimuth and SingleR (Blueprint, Monaco).
 \code{cell_annotation_azimuth_l2}: Azimuth cell annotation.
 \code{cell_annotation_blueprint_singler}: SingleR annotation (Blueprint).
-\code{cell_annotation_blueprint_monaco}: SingleR annotation (Monaco).
-\code{is_immune}: Whether a cell is an immune cell.
-\code{sample_heuristic}: Internal sample subdivision helper.
+\code{cell_annotation_monaco_singler}: SingleR annotation (Monaco).
+\code{subsets_Mito_percent}: Percent of each cell’s total counts coming from mitochondrial genes in a sample.
+\code{subsets_Ribo_percent}: Percent of each cell’s total counts coming from ribosomal genes in a sample.
+\code{high_mitochondrion}: TRUE if the cell’s mitochondrial percent exceeds the QC cutoff.
+\code{high_ribosome}: TRUE if the cell’s ribosomal percent exceeds the QC cutoff.
+\code{count_upper_bound}: Count capping threshold used in counts transformation.
+\code{inverse_transform}: Transformation method used in pre-processing pipeline.
+\code{nfeature_expressed_thresh}: Threshold of the number of expressed features per cell.
+\code{is_immune}: Curated logical flag for immune-cell context.
 \code{file_id_cellNexus_single_cell}: Internal file id for single-cell layers.
 \code{file_id_cellNexus_pseudobulk}: Internal file id for pseudobulk layers.
 \code{sample_id}: Harmonised sample identifier.

--- a/vignettes/cellNexus.Rmd
+++ b/vignettes/cellNexus.Rmd
@@ -93,27 +93,27 @@ The following sections demonstrate the metadata, quality control, generation of 
 ``` r
 metadata <- get_metadata()
 metadata
-#> # Source:   SQL [?? x 37]
+#> # Source:   SQL [?? x 31]
 #> # Database: DuckDB 1.4.3 [unknown@Linux 5.14.0-570.123.1.el9_6.x86_64:R 4.5.3/:memory:]
-#>    cell_id observation_joinid dataset_id   sample_id sample_ experiment___ run_from_cell_id sample_heuristic age_days tissue_groups nFeature_expressed_iâ€¦Â¹ nCount_RNA
-#>      <dbl> <chr>              <chr>        <chr>     <chr>   <chr>         <chr>            <chr>               <int> <chr>                          <int>      <dbl>
-#>  1       1 `;+Wwc*oS9         574e9f9e-f8â€¦ b290d7efâ€¦ b290d7â€¦ ""            <NA>             BPH556PrGA2_Fcoâ€¦    25915 prostate                        1025      113. 
-#>  2       1 s<8rT5qe3X         574e9f9e-f8â€¦ b290d7efâ€¦ b290d7â€¦ ""            <NA>             BPH556PrGA2_Fcoâ€¦    25915 prostate                        2586       77.6
-#>  3       2 Se=|eIq*={         574e9f9e-f8â€¦ b290d7efâ€¦ b290d7â€¦ ""            <NA>             BPH556PrGA2_Fcoâ€¦    25915 prostate                         992       57.6
-#>  4       2 dcNO`ReB5o         574e9f9e-f8â€¦ b290d7efâ€¦ b290d7â€¦ ""            <NA>             BPH556PrGA2_Fcoâ€¦    25915 prostate                        2002      163. 
-#>  5       3 F_Jf~Pzj<!         574e9f9e-f8â€¦ b290d7efâ€¦ b290d7â€¦ ""            <NA>             BPH556PrGA2_Fcoâ€¦    25915 prostate                         730       93.6
-#>  6      16 i(U>N;cU4_         574e9f9e-f8â€¦ b290d7efâ€¦ b290d7â€¦ ""            <NA>             BPH556PrGA2_Fcoâ€¦    25915 prostate                         718      342. 
-#>  7       4 MK~^fbPVCl         574e9f9e-f8â€¦ b290d7efâ€¦ b290d7â€¦ ""            <NA>             BPH556PrGA2_Fcoâ€¦    25915 prostate                         846       99.8
-#>  8       4 J+o&MJmtR5         574e9f9e-f8â€¦ b290d7efâ€¦ b290d7â€¦ ""            <NA>             BPH556PrGA2_Fcoâ€¦    25915 prostate                         829      123. 
-#>  9      12 $LL!IWeW`F         574e9f9e-f8â€¦ b290d7efâ€¦ b290d7â€¦ ""            <NA>             BPH556PrGA2_Fcoâ€¦    25915 prostate                        2482       61.8
-#> 10      18 $zB;$PErEP         574e9f9e-f8â€¦ b290d7efâ€¦ b290d7â€¦ ""            <NA>             BPH556PrGA2_Fcoâ€¦    25915 prostate                         828       86.6
-#> # â„¹ more rows
-#> # â„¹ abbreviated name: Â¹â€‹nFeature_expressed_in_sample
-#> # â„¹ 25 more variables: empty_droplet <lgl>, cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>, subsets_Ribo_percent <int>,
-#> #   high_mitochondrion <lgl>, high_ribosome <lgl>, scDblFinder.class <chr>, sample_chunk <int>, cell_chunk <int>, sample_pseudobulk_chunk <int>,
-#> #   file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>, inverse_transform <chr>,
-#> #   alive <lgl>, cell_annotation_blueprint_singler <chr>, cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>,
-#> #   low_confidence_ethnicity <chr>, .aggregated_cells <int>, imputed_ethnicity <chr>, atlas_id <chr>
+#>    cell_id observation_joinid dataset_id             sample_id donor_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA
+#>      <dbl> <chr>              <chr>                  <chr>     <chr>       <int> <chr>                          <int>      <dbl>
+#>  1       1 `;+Wwc*oS9         574e9f9e-f8b4-41ef-bf… b290d7ef… BPH556      25915 prostate                        1025      113. 
+#>  2       1 s<8rT5qe3X         574e9f9e-f8b4-41ef-bf… b290d7ef… BPH556      25915 prostate                        2586       77.6
+#>  3       2 Se=|eIq*={         574e9f9e-f8b4-41ef-bf… b290d7ef… BPH556      25915 prostate                         992       57.6
+#>  4       2 dcNO`ReB5o         574e9f9e-f8b4-41ef-bf… b290d7ef… BPH556      25915 prostate                        2002      163. 
+#>  5       3 F_Jf~Pzj<!         574e9f9e-f8b4-41ef-bf… b290d7ef… BPH556      25915 prostate                         730       93.6
+#>  6      16 i(U>N;cU4_         574e9f9e-f8b4-41ef-bf… b290d7ef… BPH556      25915 prostate                         718      342. 
+#>  7       4 MK~^fbPVCl         574e9f9e-f8b4-41ef-bf… b290d7ef… BPH556      25915 prostate                         846       99.8
+#>  8       4 J+o&MJmtR5         574e9f9e-f8b4-41ef-bf… b290d7ef… BPH556      25915 prostate                         829      123. 
+#>  9      12 $LL!IWeW`F         574e9f9e-f8b4-41ef-bf… b290d7ef… BPH556      25915 prostate                        2482       61.8
+#> 10      18 $zB;$PErEP         574e9f9e-f8b4-41ef-bf… b290d7ef… BPH556      25915 prostate                         828       86.6
+#> # ℹ more rows
+#> # ℹ abbreviated name: ¹​nFeature_expressed_in_sample
+#> # ℹ 22 more variables: empty_droplet <lgl>, cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>,
+#> #   subsets_Ribo_percent <int>, high_mitochondrion <lgl>, high_ribosome <lgl>, alive <lgl>, scDblFinder.class <chr>,
+#> #   file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>,
+#> #   nfeature_expressed_thresh <dbl>, inverse_transform <chr>, cell_annotation_blueprint_singler <chr>,
+#> #   cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>, …
 ```
 
 ## Quality control
@@ -140,8 +140,8 @@ Original Census annotations can be retrieved by the function `get_census_metadat
 
 ``` r
 census_metadata <- cellNexus:::get_census_metadata("2024-07-01")
-#> â„¹ Opening Census version 2024-07-01.
-#> â„¹ Reading Census obs table.
+#> ℹ Opening Census version 2024-07-01.
+#> ℹ Reading Census obs table.
 
 con <- dbplyr::remote_con(metadata)
 
@@ -165,17 +165,17 @@ metadata |>
 #> # Database: DuckDB 1.4.3 [unknown@Linux 5.14.0-570.123.1.el9_6.x86_64:R 4.5.3/:memory:]
 #>    tissue                      cell_type_unified_ensemble
 #>    <chr>                       <chr>                     
-#>  1 subcutaneous adipose tissue nkt                       
-#>  2 subcutaneous adipose tissue muscle                    
-#>  3 subcutaneous adipose tissue macrophage                
-#>  4 subcutaneous adipose tissue cd8 tem                   
-#>  5 subcutaneous adipose tissue cd16 mono                 
-#>  6 subcutaneous adipose tissue cd14 mono                 
-#>  7 subcutaneous adipose tissue b naive                   
-#>  8 subcutaneous adipose tissue cd4 th1/th17 em           
-#>  9 subcutaneous adipose tissue granulocyte               
-#> 10 subcutaneous adipose tissue cd4 naive                 
-#> # â„¹ more rows
+#>  1 transition zone of prostate cdc                       
+#>  2 transition zone of prostate epithelial                
+#>  3 transition zone of prostate b memory                  
+#>  4 transition zone of prostate endothelial               
+#>  5 transition zone of prostate monocytic                 
+#>  6 transition zone of prostate dc                        
+#>  7 transition zone of prostate nk                        
+#>  8 transition zone of prostate other                     
+#>  9 transition zone of prostate stromal                   
+#> 10 transition zone of prostate b                         
+#> # ℹ more rows
 ```
 
 ## Download single-cell RNA sequencing counts 
@@ -193,53 +193,33 @@ single_cell_counts <-
       cell_type == "T cell"
   ) |>
   get_single_cell_experiment()
-#> â„¹ Realising metadata.
-#> â„¹ Synchronising files
-#> â„¹ Reading files.
-#> 
-Reading counts â– â– â– â–                               10% | ETA: 11s
-
-Reading counts â– â– â– â– â– â– â–                            20% | ETA:  7s
-
-Reading counts â– â– â– â– â– â– â– â– â– â–                         30% | ETA:  6s
-
-Reading counts â– â– â– â– â– â– â– â– â– â– â– â– â–                      40% | ETA:  5s
-
-Reading counts â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–                   50% | ETA:  4s
-
-Reading counts â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–                60% | ETA:  3s
-
-Reading counts â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–             70% | ETA:  2s
-
-Reading counts â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–          80% | ETA:  1s
-
-Reading counts â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–       90% | ETA:  1s
-
-                                                                
-â„¹ Compiling Experiment.
+#> ℹ Realising metadata.
+#> ℹ Synchronising files
+#> ℹ Reading files.
+#> Reading counts ■■■■■■■                           20% | ETA:  9sReading counts ■■■■■■■■■■                        30% | ETA:  7sReading counts ■■■■■■■■■■■■■                     40% | ETA:  5sReading counts ■■■■■■■■■■■■■■■■                  50% | ETA:  4sReading counts ■■■■■■■■■■■■■■■■■■■               60% | ETA:  3sReading counts ■■■■■■■■■■■■■■■■■■■■■■            70% | ETA:  2sReading counts ■■■■■■■■■■■■■■■■■■■■■■■■■         80% | ETA:  1sReading counts ■■■■■■■■■■■■■■■■■■■■■■■■■■■■      90% | ETA:  1s                                                                ℹ Compiling Experiment.
 
 single_cell_counts
-#> # A SingleCellExperiment-tibble abstraction: 2,806 Ã— 60
-#> # [90mFeatures=33145 | Cells=2806 | Assays=counts[0m
-#>    .cell observation_joinid dataset_id     sample_id sample_ experiment___ run_from_cell_id sample_heuristic age_days tissue_groups nFeature_expressed_iâ€¦Â¹ nCount_RNA
-#>    <chr> <chr>              <chr>          <chr>     <chr>   <chr>         <chr>            <chr>               <int> <chr>                          <int>      <dbl>
-#>  1 80_1  zz-!e5_XAo         842c6f5d-4a94â€¦ 1de3f3baâ€¦ 1de3f3â€¦ ""            <NA>             7fabaf1c-52fd-4â€¦    14600 breast                          1749      10.8 
-#>  2 81_1  -mb&DWckf(         842c6f5d-4a94â€¦ 1de3f3baâ€¦ 1de3f3â€¦ ""            <NA>             7fabaf1c-52fd-4â€¦    14600 breast                          1993      12.4 
-#>  3 73_1  z_=CTOs4{z         842c6f5d-4a94â€¦ 4b5e66faâ€¦ 4b5e66â€¦ ""            <NA>             04983012-bb56-4â€¦    14600 breast                          2866      10.3 
-#>  4 74_1  fNzorxA`Mf         842c6f5d-4a94â€¦ 4b5e66faâ€¦ 4b5e66â€¦ ""            <NA>             04983012-bb56-4â€¦    14600 breast                          1942       7.58
-#>  5 76_1  bTlx!HK=oS         842c6f5d-4a94â€¦ 52ab9222â€¦ 52ab92â€¦ ""            <NA>             7ce86149-8906-4â€¦    14600 breast                          1671       9.65
-#>  6 77_1  E4g5+)v;AV         842c6f5d-4a94â€¦ 52ab9222â€¦ 52ab92â€¦ ""            <NA>             7ce86149-8906-4â€¦    14600 breast                          2340      11.9 
-#>  7 78_1  +q?29B%2nH         842c6f5d-4a94â€¦ 52ab9222â€¦ 52ab92â€¦ ""            <NA>             7ce86149-8906-4â€¦    14600 breast                          1714      13.2 
-#>  8 79_1  zuJ#MBMWy;         842c6f5d-4a94â€¦ 52ab9222â€¦ 52ab92â€¦ ""            <NA>             7ce86149-8906-4â€¦    14600 breast                          1506      12.3 
-#>  9 1_1   I8a42<8st4         842c6f5d-4a94â€¦ 184fa234â€¦ 184fa2â€¦ ""            <NA>             c2aa4d8d-e9df-4â€¦    14600 breast                          3395      11.8 
-#> 10 72_1  8wGs7JgUjj         842c6f5d-4a94â€¦ 6b194412â€¦ 6b1944â€¦ ""            <NA>             b3ff1aad-40fd-4â€¦    14600 breast                          2548      13.1 
-#> # â„¹ 2,796 more rows
-#> # â„¹ abbreviated name: Â¹â€‹nFeature_expressed_in_sample
-#> # â„¹ 48 more variables: empty_droplet <lgl>, cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>, subsets_Ribo_percent <int>,
-#> #   high_mitochondrion <lgl>, high_ribosome <lgl>, scDblFinder.class <chr>, sample_chunk <int>, cell_chunk <int>, sample_pseudobulk_chunk <int>,
-#> #   file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>, inverse_transform <chr>,
-#> #   alive <lgl>, cell_annotation_blueprint_singler <chr>, cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>,
-#> #   low_confidence_ethnicity <chr>, .aggregated_cells <int>, imputed_ethnicity <chr>, atlas_id <chr>, dataset_version_id <chr>, collection_id <chr>, â€¦
+#> # A SingleCellExperiment-tibble abstraction: 2,806 × 54
+#> # [90mFeatures=33145 | Cells=2806 | Assays=counts[0m
+#>    .cell observation_joinid dataset_id sample_id donor_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA empty_droplet
+#>    <chr> <chr>              <chr>      <chr>     <chr>       <int> <chr>                          <int>      <dbl> <lgl>        
+#>  1 80_1  zz-!e5_XAo         842c6f5d-… 1de3f3ba… P58         14600 breast                          1749      10.8  FALSE        
+#>  2 81_1  -mb&DWckf(         842c6f5d-… 1de3f3ba… P58         14600 breast                          1993      12.4  FALSE        
+#>  3 73_1  z_=CTOs4{z         842c6f5d-… 4b5e66fa… P39         14600 breast                          2866      10.3  FALSE        
+#>  4 74_1  fNzorxA`Mf         842c6f5d-… 4b5e66fa… P39         14600 breast                          1942       7.58 FALSE        
+#>  5 1_1   I8a42<8st4         842c6f5d-… 184fa234… P65         14600 breast                          3395      11.8  FALSE        
+#>  6 72_1  8wGs7JgUjj         842c6f5d-… 6b194412… P39         14600 breast                          2548      13.1  FALSE        
+#>  7 75_1  F9G7A+GgjA         842c6f5d-… db5a69ed… P40         14600 breast                          1291      10.2  FALSE        
+#>  8 76_1  bTlx!HK=oS         842c6f5d-… 52ab9222… P58         14600 breast                          1671       9.65 FALSE        
+#>  9 77_1  E4g5+)v;AV         842c6f5d-… 52ab9222… P58         14600 breast                          2340      11.9  FALSE        
+#> 10 78_1  +q?29B%2nH         842c6f5d-… 52ab9222… P58         14600 breast                          1714      13.2  FALSE        
+#> # ℹ 2,796 more rows
+#> # ℹ abbreviated name: ¹​nFeature_expressed_in_sample
+#> # ℹ 44 more variables: cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>,
+#> #   subsets_Ribo_percent <int>, high_mitochondrion <lgl>, high_ribosome <lgl>, alive <lgl>, scDblFinder.class <chr>,
+#> #   file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>,
+#> #   nfeature_expressed_thresh <dbl>, inverse_transform <chr>, cell_annotation_blueprint_singler <chr>,
+#> #   cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>, …
 ```
 
 ### Query counts scaled per million
@@ -255,51 +235,33 @@ single_cell_cpm <-
       cell_type == "T cell"
   ) |>
   get_single_cell_experiment(assays = "cpm")
-#> â„¹ Realising metadata.
-#> â„¹ Synchronising files
-#> â„¹ Reading files.
-#> 
-Reading cpm â– â– â– â– â– â– â–                            20% | ETA:  5s
-
-Reading cpm â– â– â– â– â– â– â– â– â– â–                         30% | ETA:  4s
-
-Reading cpm â– â– â– â– â– â– â– â– â– â– â– â– â–                      40% | ETA:  4s
-
-Reading cpm â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–                   50% | ETA:  3s
-
-Reading cpm â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–                60% | ETA:  3s
-
-Reading cpm â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–             70% | ETA:  2s
-
-Reading cpm â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–          80% | ETA:  1s
-
-Reading cpm â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–       90% | ETA:  1s
-
-                                                             
-â„¹ Compiling Experiment.
+#> ℹ Realising metadata.
+#> ℹ Synchronising files
+#> ℹ Reading files.
+#> Reading cpm ■■■■■■■                           20% | ETA:  6sReading cpm ■■■■■■■■■■                        30% | ETA:  4sReading cpm ■■■■■■■■■■■■■                     40% | ETA:  4sReading cpm ■■■■■■■■■■■■■■■■                  50% | ETA:  3sReading cpm ■■■■■■■■■■■■■■■■■■■               60% | ETA:  3sReading cpm ■■■■■■■■■■■■■■■■■■■■■■            70% | ETA:  2sReading cpm ■■■■■■■■■■■■■■■■■■■■■■■■■         80% | ETA:  1sReading cpm ■■■■■■■■■■■■■■■■■■■■■■■■■■■■      90% | ETA:  1s                                                             ℹ Compiling Experiment.
 
 single_cell_cpm
-#> # A SingleCellExperiment-tibble abstraction: 2,806 Ã— 60
-#> # [90mFeatures=33145 | Cells=2806 | Assays=cpm[0m
-#>    .cell observation_joinid dataset_id     sample_id sample_ experiment___ run_from_cell_id sample_heuristic age_days tissue_groups nFeature_expressed_iâ€¦Â¹ nCount_RNA
-#>    <chr> <chr>              <chr>          <chr>     <chr>   <chr>         <chr>            <chr>               <int> <chr>                          <int>      <dbl>
-#>  1 80_1  zz-!e5_XAo         842c6f5d-4a94â€¦ 1de3f3baâ€¦ 1de3f3â€¦ ""            <NA>             7fabaf1c-52fd-4â€¦    14600 breast                          1749      10.8 
-#>  2 81_1  -mb&DWckf(         842c6f5d-4a94â€¦ 1de3f3baâ€¦ 1de3f3â€¦ ""            <NA>             7fabaf1c-52fd-4â€¦    14600 breast                          1993      12.4 
-#>  3 73_1  z_=CTOs4{z         842c6f5d-4a94â€¦ 4b5e66faâ€¦ 4b5e66â€¦ ""            <NA>             04983012-bb56-4â€¦    14600 breast                          2866      10.3 
-#>  4 74_1  fNzorxA`Mf         842c6f5d-4a94â€¦ 4b5e66faâ€¦ 4b5e66â€¦ ""            <NA>             04983012-bb56-4â€¦    14600 breast                          1942       7.58
-#>  5 76_1  bTlx!HK=oS         842c6f5d-4a94â€¦ 52ab9222â€¦ 52ab92â€¦ ""            <NA>             7ce86149-8906-4â€¦    14600 breast                          1671       9.65
-#>  6 77_1  E4g5+)v;AV         842c6f5d-4a94â€¦ 52ab9222â€¦ 52ab92â€¦ ""            <NA>             7ce86149-8906-4â€¦    14600 breast                          2340      11.9 
-#>  7 78_1  +q?29B%2nH         842c6f5d-4a94â€¦ 52ab9222â€¦ 52ab92â€¦ ""            <NA>             7ce86149-8906-4â€¦    14600 breast                          1714      13.2 
-#>  8 79_1  zuJ#MBMWy;         842c6f5d-4a94â€¦ 52ab9222â€¦ 52ab92â€¦ ""            <NA>             7ce86149-8906-4â€¦    14600 breast                          1506      12.3 
-#>  9 1_1   I8a42<8st4         842c6f5d-4a94â€¦ 184fa234â€¦ 184fa2â€¦ ""            <NA>             c2aa4d8d-e9df-4â€¦    14600 breast                          3395      11.8 
-#> 10 72_1  8wGs7JgUjj         842c6f5d-4a94â€¦ 6b194412â€¦ 6b1944â€¦ ""            <NA>             b3ff1aad-40fd-4â€¦    14600 breast                          2548      13.1 
-#> # â„¹ 2,796 more rows
-#> # â„¹ abbreviated name: Â¹â€‹nFeature_expressed_in_sample
-#> # â„¹ 48 more variables: empty_droplet <lgl>, cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>, subsets_Ribo_percent <int>,
-#> #   high_mitochondrion <lgl>, high_ribosome <lgl>, scDblFinder.class <chr>, sample_chunk <int>, cell_chunk <int>, sample_pseudobulk_chunk <int>,
-#> #   file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>, inverse_transform <chr>,
-#> #   alive <lgl>, cell_annotation_blueprint_singler <chr>, cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>,
-#> #   low_confidence_ethnicity <chr>, .aggregated_cells <int>, imputed_ethnicity <chr>, atlas_id <chr>, dataset_version_id <chr>, collection_id <chr>, â€¦
+#> # A SingleCellExperiment-tibble abstraction: 2,806 × 54
+#> # [90mFeatures=33145 | Cells=2806 | Assays=cpm[0m
+#>    .cell observation_joinid dataset_id sample_id donor_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA empty_droplet
+#>    <chr> <chr>              <chr>      <chr>     <chr>       <int> <chr>                          <int>      <dbl> <lgl>        
+#>  1 76_1  bTlx!HK=oS         842c6f5d-… 52ab9222… P58         14600 breast                          1671       9.65 FALSE        
+#>  2 77_1  E4g5+)v;AV         842c6f5d-… 52ab9222… P58         14600 breast                          2340      11.9  FALSE        
+#>  3 78_1  +q?29B%2nH         842c6f5d-… 52ab9222… P58         14600 breast                          1714      13.2  FALSE        
+#>  4 79_1  zuJ#MBMWy;         842c6f5d-… 52ab9222… P58         14600 breast                          1506      12.3  FALSE        
+#>  5 1_1   I8a42<8st4         842c6f5d-… 184fa234… P65         14600 breast                          3395      11.8  FALSE        
+#>  6 72_1  8wGs7JgUjj         842c6f5d-… 6b194412… P39         14600 breast                          2548      13.1  FALSE        
+#>  7 75_1  F9G7A+GgjA         842c6f5d-… db5a69ed… P40         14600 breast                          1291      10.2  FALSE        
+#>  8 80_1  zz-!e5_XAo         842c6f5d-… 1de3f3ba… P58         14600 breast                          1749      10.8  FALSE        
+#>  9 81_1  -mb&DWckf(         842c6f5d-… 1de3f3ba… P58         14600 breast                          1993      12.4  FALSE        
+#> 10 73_1  z_=CTOs4{z         842c6f5d-… 4b5e66fa… P39         14600 breast                          2866      10.3  FALSE        
+#> # ℹ 2,796 more rows
+#> # ℹ abbreviated name: ¹​nFeature_expressed_in_sample
+#> # ℹ 44 more variables: cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>,
+#> #   subsets_Ribo_percent <int>, high_mitochondrion <lgl>, high_ribosome <lgl>, alive <lgl>, scDblFinder.class <chr>,
+#> #   file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>,
+#> #   nfeature_expressed_thresh <dbl>, inverse_transform <chr>, cell_annotation_blueprint_singler <chr>,
+#> #   cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>, …
 ```
 
 ### Query SCT normalised counts
@@ -314,65 +276,38 @@ single_cell_sct <-
       cell_type == "T cell"
   ) |>
   get_single_cell_experiment(assays = "sct")
-#> â„¹ Realising metadata.
-#> â„¹ Synchronising files
-#> â„¹ Reading files.
+#> ℹ Realising metadata.
+#> ℹ Synchronising files
+#> ℹ Reading files.
 #> ! The number of cells in the SingleCellExperiment will be less than the number of cells you have selected from the metadata. Are cell IDs duplicated? Or, do cell IDs correspond to the counts file?
-#> 
-Reading sct â– â– â– â– â– â– â–                            20% | ETA:  5s
-
-Reading sct â– â– â– â– â– â– â– â– â– â–                         30% | ETA:  4s
-
-Reading sct â– â– â– â– â– â– â– â– â– â– â– â– â–                      40% | ETA:  4s
-
-                                                             
-! The number of cells in the SingleCellExperiment will be less than the number of cells you have selected from the metadata. Are cell IDs duplicated? Or, do cell IDs correspond to the counts file?
-#> Reading sct â– â– â– â– â– â– â– â– â– â– â– â– â–                      40% | ETA:  4s
-
-Reading sct â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–                   50% | ETA:  3s
-
-                                                             
-! The number of cells in the SingleCellExperiment will be less than the number of cells you have selected from the metadata. Are cell IDs duplicated? Or, do cell IDs correspond to the counts file?
-#> Reading sct â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–                   50% | ETA:  3s
-
-Reading sct â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–                60% | ETA:  3s
-
-Reading sct â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–             70% | ETA:  2s
-
-                                                             
-! The number of cells in the SingleCellExperiment will be less than the number of cells you have selected from the metadata. Are cell IDs duplicated? Or, do cell IDs correspond to the counts file?
-#> Reading sct â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–             70% | ETA:  2s
-
-Reading sct â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–          80% | ETA:  1s
-
-Reading sct â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–       90% | ETA:  1s
-
-                                                             
-! cellNexus says: 1613 cell(s) from your metadata are absent from the SCT assay across 4 file(s). This is expected: SCT normalisation is run per sample and may fail for samples with very few cells or extreme count distributions. The returned object contains only cells from samples where SCT succeeded. Affected sample_id(s): 52ab92226337d36c306466eefe67f9c1, 765554078ca8d1eaf2712000c0df0d6f, 8940e0767e7eca1b72d37b4138be2276, a79912cb9aaa8d8c0b1a3cdcc9294f8c, 5e641a2218d1d8b91f638989626c89e0.
-#> â„¹ Compiling Experiment.
+#> Reading sct ■■■■■■■                           20% | ETA:  5sReading sct ■■■■■■■■■■                        30% | ETA:  4sReading sct ■■■■■■■■■■■■■                     40% | ETA:  4s                                                             ! The number of cells in the SingleCellExperiment will be less than the number of cells you have selected from the metadata. Are cell IDs duplicated? Or, do cell IDs correspond to the counts file?
+#> Reading sct ■■■■■■■■■■■■■                     40% | ETA:  4sReading sct ■■■■■■■■■■■■■■■■                  50% | ETA:  3s                                                             ! The number of cells in the SingleCellExperiment will be less than the number of cells you have selected from the metadata. Are cell IDs duplicated? Or, do cell IDs correspond to the counts file?
+#> Reading sct ■■■■■■■■■■■■■■■■                  50% | ETA:  3sReading sct ■■■■■■■■■■■■■■■■■■■               60% | ETA:  2sReading sct ■■■■■■■■■■■■■■■■■■■■■■            70% | ETA:  2s                                                             ! The number of cells in the SingleCellExperiment will be less than the number of cells you have selected from the metadata. Are cell IDs duplicated? Or, do cell IDs correspond to the counts file?
+#> Reading sct ■■■■■■■■■■■■■■■■■■■■■■            70% | ETA:  2sReading sct ■■■■■■■■■■■■■■■■■■■■■■■■■         80% | ETA:  1sReading sct ■■■■■■■■■■■■■■■■■■■■■■■■■■■■      90% | ETA:  1s                                                             ! cellNexus says: 1613 cell(s) from your metadata are absent from the SCT assay across 4 file(s). This is expected: SCT normalisation is run per sample and may fail for samples with very few cells or extreme count distributions. The returned object contains only cells from samples where SCT succeeded. Affected sample_id(s): 52ab92226337d36c306466eefe67f9c1, 765554078ca8d1eaf2712000c0df0d6f, 8940e0767e7eca1b72d37b4138be2276, a79912cb9aaa8d8c0b1a3cdcc9294f8c, 5e641a2218d1d8b91f638989626c89e0.
+#> ℹ Compiling Experiment.
 
 single_cell_sct
-#> # A SingleCellExperiment-tibble abstraction: 1,193 Ã— 60
-#> # [90mFeatures=33145 | Cells=1193 | Assays=sct[0m
-#>    .cell observation_joinid dataset_id     sample_id sample_ experiment___ run_from_cell_id sample_heuristic age_days tissue_groups nFeature_expressed_iâ€¦Â¹ nCount_RNA
-#>    <chr> <chr>              <chr>          <chr>     <chr>   <chr>         <chr>            <chr>               <int> <chr>                          <int>      <dbl>
-#>  1 80_1  zz-!e5_XAo         842c6f5d-4a94â€¦ 1de3f3baâ€¦ 1de3f3â€¦ ""            <NA>             7fabaf1c-52fd-4â€¦    14600 breast                          1749      10.8 
-#>  2 81_1  -mb&DWckf(         842c6f5d-4a94â€¦ 1de3f3baâ€¦ 1de3f3â€¦ ""            <NA>             7fabaf1c-52fd-4â€¦    14600 breast                          1993      12.4 
-#>  3 73_1  z_=CTOs4{z         842c6f5d-4a94â€¦ 4b5e66faâ€¦ 4b5e66â€¦ ""            <NA>             04983012-bb56-4â€¦    14600 breast                          2866      10.3 
-#>  4 74_1  fNzorxA`Mf         842c6f5d-4a94â€¦ 4b5e66faâ€¦ 4b5e66â€¦ ""            <NA>             04983012-bb56-4â€¦    14600 breast                          1942       7.58
-#>  5 1_1   I8a42<8st4         842c6f5d-4a94â€¦ 184fa234â€¦ 184fa2â€¦ ""            <NA>             c2aa4d8d-e9df-4â€¦    14600 breast                          3395      11.8 
-#>  6 72_1  8wGs7JgUjj         842c6f5d-4a94â€¦ 6b194412â€¦ 6b1944â€¦ ""            <NA>             b3ff1aad-40fd-4â€¦    14600 breast                          2548      13.1 
-#>  7 75_1  F9G7A+GgjA         842c6f5d-4a94â€¦ db5a69edâ€¦ db5a69â€¦ ""            <NA>             49beb83c-66a1-4â€¦    14600 breast                          1291      10.2 
-#>  8 1_2   >8f0}-gXFY         842c6f5d-4a94â€¦ 81d05f17â€¦ 81d05fâ€¦ ""            <NA>             b866c1d4-3dfd-4â€¦    14600 breast                          2513      13.3 
-#>  9 22_2  2lQ`<&l3-A         842c6f5d-4a94â€¦ 30967738â€¦ 309677â€¦ ""            <NA>             7d4045ff-3f48-4â€¦    14600 breast                          2058       9.91
-#> 10 5_2   +p4uNj_7$S         842c6f5d-4a94â€¦ a91e6814â€¦ a91e68â€¦ ""            <NA>             700a819c-03f9-4â€¦    14600 breast                          1870      11.1 
-#> # â„¹ 1,183 more rows
-#> # â„¹ abbreviated name: Â¹â€‹nFeature_expressed_in_sample
-#> # â„¹ 48 more variables: empty_droplet <lgl>, cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>, subsets_Ribo_percent <int>,
-#> #   high_mitochondrion <lgl>, high_ribosome <lgl>, scDblFinder.class <chr>, sample_chunk <int>, cell_chunk <int>, sample_pseudobulk_chunk <int>,
-#> #   file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>, inverse_transform <chr>,
-#> #   alive <lgl>, cell_annotation_blueprint_singler <chr>, cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>,
-#> #   low_confidence_ethnicity <chr>, .aggregated_cells <int>, imputed_ethnicity <chr>, atlas_id <chr>, dataset_version_id <chr>, collection_id <chr>, â€¦
+#> # A SingleCellExperiment-tibble abstraction: 1,193 × 54
+#> # [90mFeatures=33145 | Cells=1193 | Assays=sct[0m
+#>    .cell observation_joinid dataset_id sample_id donor_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA empty_droplet
+#>    <chr> <chr>              <chr>      <chr>     <chr>       <int> <chr>                          <int>      <dbl> <lgl>        
+#>  1 80_1  zz-!e5_XAo         842c6f5d-… 1de3f3ba… P58         14600 breast                          1749      10.8  FALSE        
+#>  2 81_1  -mb&DWckf(         842c6f5d-… 1de3f3ba… P58         14600 breast                          1993      12.4  FALSE        
+#>  3 72_1  8wGs7JgUjj         842c6f5d-… 6b194412… P39         14600 breast                          2548      13.1  FALSE        
+#>  4 75_1  F9G7A+GgjA         842c6f5d-… db5a69ed… P40         14600 breast                          1291      10.2  FALSE        
+#>  5 73_1  z_=CTOs4{z         842c6f5d-… 4b5e66fa… P39         14600 breast                          2866      10.3  FALSE        
+#>  6 74_1  fNzorxA`Mf         842c6f5d-… 4b5e66fa… P39         14600 breast                          1942       7.58 FALSE        
+#>  7 1_1   I8a42<8st4         842c6f5d-… 184fa234… P65         14600 breast                          3395      11.8  FALSE        
+#>  8 1_2   >8f0}-gXFY         842c6f5d-… 81d05f17… P63         14600 breast                          2513      13.3  FALSE        
+#>  9 22_2  2lQ`<&l3-A         842c6f5d-… 30967738… P57         14600 breast                          2058       9.91 FALSE        
+#> 10 23_2  sqV-|vcI4R         842c6f5d-… d8ecdd92… P41         14600 breast                          2375      13.7  FALSE        
+#> # ℹ 1,183 more rows
+#> # ℹ abbreviated name: ¹​nFeature_expressed_in_sample
+#> # ℹ 44 more variables: cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>,
+#> #   subsets_Ribo_percent <int>, high_mitochondrion <lgl>, high_ribosome <lgl>, alive <lgl>, scDblFinder.class <chr>,
+#> #   file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>,
+#> #   nfeature_expressed_thresh <dbl>, inverse_transform <chr>, cell_annotation_blueprint_singler <chr>,
+#> #   cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>, …
 ```
 
 ### Query pseudobulk
@@ -386,53 +321,39 @@ pseudobulk_counts <-
       cell_type == "classical monocyte"
   ) |>
   get_pseudobulk()
-#> â„¹ Realising metadata.
-#> â„¹ Synchronising files
-#> â„¹ Reading files.
-#> 
-Reading counts â– â– â– â– â–                              14% | ETA:  8s
-
-Reading counts â– â– â– â– â– â– â– â– â– â–                         29% | ETA: 11s
-
-Reading counts â– â– â– â– â– â– â– â– â– â– â– â– â– â–                     43% | ETA:  9s
-
-Reading counts â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–                 57% | ETA:  6s
-
-Reading counts â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–             71% | ETA:  4s
-
-Reading counts â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–        86% | ETA:  2s
-
-                                                                
-! cellNexus says: Not all genes completely overlap across the provided objects. Counts are generated by genes intersection.
-#> â„¹ Compiling Experiment.
+#> ℹ Realising metadata.
+#> ℹ Synchronising files
+#> ℹ Reading files.
+#> Reading counts ■■■■■                             14% | ETA:  9sReading counts ■■■■■■■■■■                        29% | ETA:  9sReading counts ■■■■■■■■■■■■■■                    43% | ETA:  7sReading counts ■■■■■■■■■■■■■■■■■■                57% | ETA:  5sReading counts ■■■■■■■■■■■■■■■■■■■■■■            71% | ETA:  4sReading counts ■■■■■■■■■■■■■■■■■■■■■■■■■■■       86% | ETA:  2s                                                                ! cellNexus says: Not all genes completely overlap across the provided objects. Counts are generated by genes intersection.
+#> ℹ Compiling Experiment.
 
 pseudobulk_counts
-#> # A SingleCellExperiment-tibble abstraction: 139 Ã— 43
-#> # [90mFeatures=15888 | Cells=139 | Assays=counts[0m
-#>    .cell           dataset_id sample_id sample_ experiment___ run_from_cell_id sample_heuristic age_days tissue_groups cell_type_unified_enâ€¦Â¹ sample_chunk cell_chunk
-#>    <chr>           <chr>      <chr>     <chr>   <chr>         <chr>            <chr>               <int> <chr>         <chr>                         <int>      <int>
-#>  1 2e8c9911c9bfbfâ€¦ 0ba16f4b-â€¦ 2e8c9911â€¦ 2e8c99â€¦ ""            <NA>             HDBR15279,HDBR1â€¦       NA respiratory â€¦ cd14 mono                         1          1
-#>  2 0d874636bc714aâ€¦ 1e6a6ef9-â€¦ 0d874636â€¦ 0d8746â€¦ ""            <NA>             Leader_Merad_20â€¦    29930 respiratory â€¦ monocytic                         1          5
-#>  3 0d874636bc714aâ€¦ 1e6a6ef9-â€¦ 0d874636â€¦ 0d8746â€¦ ""            <NA>             Leader_Merad_20â€¦    29930 respiratory â€¦ cd14 mono                         1          5
-#>  4 0d874636bc714aâ€¦ 1e6a6ef9-â€¦ 0d874636â€¦ 0d8746â€¦ ""            <NA>             Leader_Merad_20â€¦    29930 respiratory â€¦ cd16 mono                         1          5
-#>  5 0d874636bc714aâ€¦ 1e6a6ef9-â€¦ 0d874636â€¦ 0d8746â€¦ ""            <NA>             Leader_Merad_20â€¦    29930 respiratory â€¦ macrophage                        1          5
-#>  6 0d874636bc714aâ€¦ 1e6a6ef9-â€¦ 0d874636â€¦ 0d8746â€¦ ""            <NA>             Leader_Merad_20â€¦    29930 respiratory â€¦ other                             1          5
-#>  7 11721339cb1dfcâ€¦ 1e6a6ef9-â€¦ 11721339â€¦ 117213â€¦ ""            <NA>             Leader_Merad_20â€¦    26645 respiratory â€¦ monocytic                         1          7
-#>  8 11721339cb1dfcâ€¦ 1e6a6ef9-â€¦ 11721339â€¦ 117213â€¦ ""            <NA>             Leader_Merad_20â€¦    26645 respiratory â€¦ cd14 mono                         1          7
-#>  9 f71af64a552d45â€¦ 1e6a6ef9-â€¦ f71af64aâ€¦ f71af6â€¦ ""            <NA>             Leader_Merad_20â€¦    27010 respiratory â€¦ monocytic                         1          6
-#> 10 f71af64a552d45â€¦ 1e6a6ef9-â€¦ f71af64aâ€¦ f71af6â€¦ ""            <NA>             Leader_Merad_20â€¦    27010 respiratory â€¦ cd14 mono                         1          6
-#> # â„¹ 129 more rows
-#> # â„¹ abbreviated name: Â¹â€‹cell_type_unified_ensemble
-#> # â„¹ 31 more variables: sample_pseudobulk_chunk <int>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>,
-#> #   inverse_transform <chr>, ethnicity_flagging_score <dbl>, low_confidence_ethnicity <chr>, .aggregated_cells <int>, imputed_ethnicity <chr>, atlas_id <chr>,
-#> #   dataset_version_id <chr>, collection_id <chr>, cell_count <int>, citation <chr>, default_embedding <chr>, explorer_url <chr>, feature_count <int>,
-#> #   mean_genes_per_cell <dbl>, primary_cell_count <int>, schema_version <chr>, title <chr>, tombstone <lgl>, x_approximate_distribution <chr>, published_at <date>,
-#> #   revised_at <date>, tissue <chr>, self_reported_ethnicity <chr>, assay <chr>, disease <chr>, sex <chr>, sample_identifier <chr>
+#> # A SingleCellExperiment-tibble abstraction: 146 × 46
+#> # [90mFeatures=15888 | Cells=146 | Assays=counts[0m
+#>    .cell  sample_id cell_type_unified_en…¹ dataset_id donor_id age_days tissue_groups empty_droplet is_immune high_mitochondrion
+#>    <chr>  <chr>     <chr>                  <chr>      <chr>       <int> <chr>         <lgl>         <lgl>     <lgl>             
+#>  1 2e8c9… 2e8c9911… cd14 mono              0ba16f4b-… HDBR152…       NA respiratory … FALSE         TRUE      FALSE             
+#>  2 f71af… f71af64a… monocytic              1e6a6ef9-… Leader_…    27010 respiratory … FALSE         TRUE      FALSE             
+#>  3 f71af… f71af64a… cd14 mono              1e6a6ef9-… Leader_…    27010 respiratory … FALSE         TRUE      FALSE             
+#>  4 f71af… f71af64a… cd8 tem                1e6a6ef9-… Leader_…    27010 respiratory … FALSE         TRUE      FALSE             
+#>  5 11721… 11721339… monocytic              1e6a6ef9-… Leader_…    26645 respiratory … FALSE         TRUE      FALSE             
+#>  6 11721… 11721339… cd14 mono              1e6a6ef9-… Leader_…    26645 respiratory … FALSE         TRUE      FALSE             
+#>  7 0d874… 0d874636… cd14 mono              1e6a6ef9-… Leader_…    29930 respiratory … FALSE         TRUE      FALSE             
+#>  8 0d874… 0d874636… cd16 mono              1e6a6ef9-… Leader_…    29930 respiratory … FALSE         TRUE      FALSE             
+#>  9 0d874… 0d874636… macrophage             1e6a6ef9-… Leader_…    29930 respiratory … FALSE         TRUE      FALSE             
+#> 10 0d874… 0d874636… monocytic              1e6a6ef9-… Leader_…    29930 respiratory … FALSE         TRUE      FALSE             
+#> # ℹ 136 more rows
+#> # ℹ abbreviated name: ¹​cell_type_unified_ensemble
+#> # ℹ 36 more variables: alive <lgl>, scDblFinder.class <chr>, file_id_cellNexus_single_cell <chr>,
+#> #   file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>, inverse_transform <chr>,
+#> #   cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>, low_confidence_ethnicity <chr>, .aggregated_cells <int>,
+#> #   imputed_ethnicity <chr>, atlas_id <chr>, dataset_version_id <chr>, collection_id <chr>, cell_count <int>, citation <chr>,
+#> #   default_embedding <chr>, explorer_url <chr>, feature_count <int>, mean_genes_per_cell <dbl>, primary_cell_count <int>, …
 ```
 
 ## Download cell communication metadata
 
-Cell communication metadata was generated based on post-QC cells per sample using `CellChat v2` method. It uses our harmonised cell type annotation (cell_type_unified_ensemble) to infer the communication. It captures inferred communication at both the ligandâ€“receptor pair level and the signalling pathway level.  
+Cell communication metadata was generated based on post-QC cells per sample using `CellChat v2` method. It uses our harmonised cell type annotation (cell_type_unified_ensemble) to infer the communication. It captures inferred communication at both the ligand–receptor pair level and the signalling pathway level.  
 
 - interaction_count: The number of inferred interactions between each pair of cell groups.  
 
@@ -446,15 +367,16 @@ For demonstration purpose, read cell communication metadata from a demo file her
 get_cell_communication_strength(cloud_metadata = get_metadata_url("cellNexus_lr_signaling_pathway_strength_DEMO.parquet"))
 #> # Source:   SQL [?? x 16]
 #> # Database: DuckDB 1.4.3 [unknown@Linux 5.14.0-570.123.1.el9_6.x86_64:R 4.5.3/:memory:]
-#>   source    target ligand receptor   lr_prob lr_pval interaction_name    interaction_name_2      pathway_name annotation evidence pathway_prob pathway_pval sample_id
-#>   <chr>     <chr>  <chr>  <chr>        <dbl>   <dbl> <chr>               <chr>                   <chr>        <chr>      <chr>           <dbl>        <dbl> <chr>    
-#> 1 b         b      TGFB1  TGFbR1_R2 0.000116    1    TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR2) TGFb         Secreted â€¦ KEGG: hâ€¦     0.000420        1     b290d7efâ€¦
-#> 2 b memory  b      TGFB1  TGFbR1_R2 0.000865    1    TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR2) TGFb         Secreted â€¦ KEGG: hâ€¦     0.00185         1     b290d7efâ€¦
-#> 3 b naive   b      TGFB1  TGFbR1_R2 0.000696    0.99 TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR2) TGFb         Secreted â€¦ KEGG: hâ€¦     0.00146         0.994 b290d7efâ€¦
-#> 4 cd14 mono b      TGFB1  TGFbR1_R2 0.00240     0.81 TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR2) TGFb         Secreted â€¦ KEGG: hâ€¦     0.00472         0.924 b290d7efâ€¦
-#> 5 cd4 naive b      TGFB1  TGFbR1_R2 0.000957    1    TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR2) TGFb         Secreted â€¦ KEGG: hâ€¦     0.00201         0.998 b290d7efâ€¦
-#> 6 cd4 tem   b      TGFB1  TGFbR1_R2 0.00242     0.76 TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR2) TGFb         Secreted â€¦ KEGG: hâ€¦     0.00467         0.797 b290d7efâ€¦
-#> # â„¹ 2 more variables: interaction_count <dbl>, interaction_weight <dbl>
+#>   source    target ligand receptor   lr_prob lr_pval interaction_name    interaction_name_2     pathway_name annotation evidence
+#>   <chr>     <chr>  <chr>  <chr>        <dbl>   <dbl> <chr>               <chr>                  <chr>        <chr>      <chr>   
+#> 1 b         b      TGFB1  TGFbR1_R2 0.000116    1    TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR… TGFb         Secreted … KEGG: h…
+#> 2 b memory  b      TGFB1  TGFbR1_R2 0.000865    1    TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR… TGFb         Secreted … KEGG: h…
+#> 3 b naive   b      TGFB1  TGFbR1_R2 0.000696    0.99 TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR… TGFb         Secreted … KEGG: h…
+#> 4 cd14 mono b      TGFB1  TGFbR1_R2 0.00240     0.81 TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR… TGFb         Secreted … KEGG: h…
+#> 5 cd4 naive b      TGFB1  TGFbR1_R2 0.000957    1    TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR… TGFb         Secreted … KEGG: h…
+#> 6 cd4 tem   b      TGFB1  TGFbR1_R2 0.00242     0.76 TGFB1_TGFBR1_TGFBR2 TGFB1 - (TGFBR1+TGFBR… TGFb         Secreted … KEGG: h…
+#> # ℹ 5 more variables: pathway_prob <dbl>, pathway_pval <dbl>, sample_id <chr>, interaction_count <dbl>,
+#> #   interaction_weight <dbl>
 ```
 
 ### Extract only a subset of genes
@@ -472,51 +394,33 @@ single_cell_cpm <-
       cell_type == "T cell"
   ) |>
   get_single_cell_experiment(assays = "cpm", features = "ENSG00000134644")
-#> â„¹ Realising metadata.
-#> â„¹ Synchronising files
-#> â„¹ Reading files.
-#> 
-Reading cpm â– â– â– â– â– â– â–                            20% | ETA:  5s
-
-Reading cpm â– â– â– â– â– â– â– â– â– â–                         30% | ETA:  4s
-
-Reading cpm â– â– â– â– â– â– â– â– â– â– â– â– â–                      40% | ETA:  4s
-
-Reading cpm â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–                   50% | ETA:  3s
-
-Reading cpm â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–                60% | ETA:  3s
-
-Reading cpm â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–             70% | ETA:  2s
-
-Reading cpm â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–          80% | ETA:  1s
-
-Reading cpm â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–       90% | ETA:  1s
-
-                                                             
-â„¹ Compiling Experiment.
+#> ℹ Realising metadata.
+#> ℹ Synchronising files
+#> ℹ Reading files.
+#> Reading cpm ■■■■■■■                           20% | ETA:  4sReading cpm ■■■■■■■■■■                        30% | ETA:  4sReading cpm ■■■■■■■■■■■■■                     40% | ETA:  3sReading cpm ■■■■■■■■■■■■■■■■                  50% | ETA:  3sReading cpm ■■■■■■■■■■■■■■■■■■■               60% | ETA:  2sReading cpm ■■■■■■■■■■■■■■■■■■■■■■            70% | ETA:  2sReading cpm ■■■■■■■■■■■■■■■■■■■■■■■■■         80% | ETA:  1sReading cpm ■■■■■■■■■■■■■■■■■■■■■■■■■■■■      90% | ETA:  1s                                                             ℹ Compiling Experiment.
 
 single_cell_cpm
-#> # A SingleCellExperiment-tibble abstraction: 2,806 Ã— 60
-#> # [90mFeatures=1 | Cells=2806 | Assays=cpm[0m
-#>    .cell observation_joinid dataset_id     sample_id sample_ experiment___ run_from_cell_id sample_heuristic age_days tissue_groups nFeature_expressed_iâ€¦Â¹ nCount_RNA
-#>    <chr> <chr>              <chr>          <chr>     <chr>   <chr>         <chr>            <chr>               <int> <chr>                          <int>      <dbl>
-#>  1 80_1  zz-!e5_XAo         842c6f5d-4a94â€¦ 1de3f3baâ€¦ 1de3f3â€¦ ""            <NA>             7fabaf1c-52fd-4â€¦    14600 breast                          1749      10.8 
-#>  2 81_1  -mb&DWckf(         842c6f5d-4a94â€¦ 1de3f3baâ€¦ 1de3f3â€¦ ""            <NA>             7fabaf1c-52fd-4â€¦    14600 breast                          1993      12.4 
-#>  3 72_1  8wGs7JgUjj         842c6f5d-4a94â€¦ 6b194412â€¦ 6b1944â€¦ ""            <NA>             b3ff1aad-40fd-4â€¦    14600 breast                          2548      13.1 
-#>  4 75_1  F9G7A+GgjA         842c6f5d-4a94â€¦ db5a69edâ€¦ db5a69â€¦ ""            <NA>             49beb83c-66a1-4â€¦    14600 breast                          1291      10.2 
-#>  5 73_1  z_=CTOs4{z         842c6f5d-4a94â€¦ 4b5e66faâ€¦ 4b5e66â€¦ ""            <NA>             04983012-bb56-4â€¦    14600 breast                          2866      10.3 
-#>  6 74_1  fNzorxA`Mf         842c6f5d-4a94â€¦ 4b5e66faâ€¦ 4b5e66â€¦ ""            <NA>             04983012-bb56-4â€¦    14600 breast                          1942       7.58
-#>  7 76_1  bTlx!HK=oS         842c6f5d-4a94â€¦ 52ab9222â€¦ 52ab92â€¦ ""            <NA>             7ce86149-8906-4â€¦    14600 breast                          1671       9.65
-#>  8 77_1  E4g5+)v;AV         842c6f5d-4a94â€¦ 52ab9222â€¦ 52ab92â€¦ ""            <NA>             7ce86149-8906-4â€¦    14600 breast                          2340      11.9 
-#>  9 78_1  +q?29B%2nH         842c6f5d-4a94â€¦ 52ab9222â€¦ 52ab92â€¦ ""            <NA>             7ce86149-8906-4â€¦    14600 breast                          1714      13.2 
-#> 10 79_1  zuJ#MBMWy;         842c6f5d-4a94â€¦ 52ab9222â€¦ 52ab92â€¦ ""            <NA>             7ce86149-8906-4â€¦    14600 breast                          1506      12.3 
-#> # â„¹ 2,796 more rows
-#> # â„¹ abbreviated name: Â¹â€‹nFeature_expressed_in_sample
-#> # â„¹ 48 more variables: empty_droplet <lgl>, cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>, subsets_Ribo_percent <int>,
-#> #   high_mitochondrion <lgl>, high_ribosome <lgl>, scDblFinder.class <chr>, sample_chunk <int>, cell_chunk <int>, sample_pseudobulk_chunk <int>,
-#> #   file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>, inverse_transform <chr>,
-#> #   alive <lgl>, cell_annotation_blueprint_singler <chr>, cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>,
-#> #   low_confidence_ethnicity <chr>, .aggregated_cells <int>, imputed_ethnicity <chr>, atlas_id <chr>, dataset_version_id <chr>, collection_id <chr>, â€¦
+#> # A SingleCellExperiment-tibble abstraction: 2,806 × 54
+#> # [90mFeatures=1 | Cells=2806 | Assays=cpm[0m
+#>    .cell observation_joinid dataset_id sample_id donor_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA empty_droplet
+#>    <chr> <chr>              <chr>      <chr>     <chr>       <int> <chr>                          <int>      <dbl> <lgl>        
+#>  1 76_1  bTlx!HK=oS         842c6f5d-… 52ab9222… P58         14600 breast                          1671       9.65 FALSE        
+#>  2 77_1  E4g5+)v;AV         842c6f5d-… 52ab9222… P58         14600 breast                          2340      11.9  FALSE        
+#>  3 78_1  +q?29B%2nH         842c6f5d-… 52ab9222… P58         14600 breast                          1714      13.2  FALSE        
+#>  4 79_1  zuJ#MBMWy;         842c6f5d-… 52ab9222… P58         14600 breast                          1506      12.3  FALSE        
+#>  5 72_1  8wGs7JgUjj         842c6f5d-… 6b194412… P39         14600 breast                          2548      13.1  FALSE        
+#>  6 75_1  F9G7A+GgjA         842c6f5d-… db5a69ed… P40         14600 breast                          1291      10.2  FALSE        
+#>  7 80_1  zz-!e5_XAo         842c6f5d-… 1de3f3ba… P58         14600 breast                          1749      10.8  FALSE        
+#>  8 81_1  -mb&DWckf(         842c6f5d-… 1de3f3ba… P58         14600 breast                          1993      12.4  FALSE        
+#>  9 73_1  z_=CTOs4{z         842c6f5d-… 4b5e66fa… P39         14600 breast                          2866      10.3  FALSE        
+#> 10 74_1  fNzorxA`Mf         842c6f5d-… 4b5e66fa… P39         14600 breast                          1942       7.58 FALSE        
+#> # ℹ 2,796 more rows
+#> # ℹ abbreviated name: ¹​nFeature_expressed_in_sample
+#> # ℹ 44 more variables: cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>,
+#> #   subsets_Ribo_percent <int>, high_mitochondrion <lgl>, high_ribosome <lgl>, alive <lgl>, scDblFinder.class <chr>,
+#> #   file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>,
+#> #   nfeature_expressed_thresh <dbl>, inverse_transform <chr>, cell_annotation_blueprint_singler <chr>,
+#> #   cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>, …
 ```
 
 ### Extract the counts as a Seurat object
@@ -534,34 +438,33 @@ seurat_counts <-
       cell_type == "T cell"
   ) |>
   get_seurat()
-#> â„¹ Realising metadata.
-#> â„¹ Synchronising files
-#> â„¹ Reading files.
-#> 
-Reading counts â– â– â– â– â– â– â–                            20% | ETA:  5s
-
-Reading counts â– â– â– â– â– â– â– â– â– â–                         30% | ETA:  5s
-
-Reading counts â– â– â– â– â– â– â– â– â– â– â– â– â–                      40% | ETA:  4s
-
-Reading counts â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–                   50% | ETA:  3s
-
-Reading counts â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–                60% | ETA:  3s
-
-Reading counts â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–             70% | ETA:  3s
-
-Reading counts â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–          80% | ETA:  2s
-
-Reading counts â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â– â–       90% | ETA:  1s
-
-                                                                
-â„¹ Compiling Experiment.
+#> ℹ Realising metadata.
+#> ℹ Synchronising files
+#> ℹ Reading files.
+#> Reading counts ■■■■■■■                           20% | ETA:  4sReading counts ■■■■■■■■■■                        30% | ETA:  4sReading counts ■■■■■■■■■■■■■                     40% | ETA:  3sReading counts ■■■■■■■■■■■■■■■■                  50% | ETA:  3sReading counts ■■■■■■■■■■■■■■■■■■■               60% | ETA:  2sReading counts ■■■■■■■■■■■■■■■■■■■■■■            70% | ETA:  2sReading counts ■■■■■■■■■■■■■■■■■■■■■■■■■         80% | ETA:  1sReading counts ■■■■■■■■■■■■■■■■■■■■■■■■■■■■      90% | ETA:  1s                                                                ℹ Compiling Experiment.
 
 seurat_counts
-#> An object of class Seurat 
-#> 33145 features across 2806 samples within 1 assay 
-#> Active assay: originalexp (33145 features, 0 variable features)
-#>  2 layers present: counts, data
+#> # A Seurat-tibble abstraction: 2,806 × 59
+#> # [90mFeatures=33145 | Cells=2806 | Active assay=counts | Assays=counts[0m
+#>    .cell orig.ident    nCount_originalexp nFeature_originalexp observation_joinid dataset_id         sample_id donor_id age_days
+#>    <chr> <fct>                      <dbl>                <int> <chr>              <chr>              <chr>     <chr>       <int>
+#>  1 73_1  SeuratProject               14.1                 2958 z_=CTOs4{z         842c6f5d-4a94-4ee… 4b5e66fa… P39         14600
+#>  2 74_1  SeuratProject               14.2                 2035 fNzorxA`Mf         842c6f5d-4a94-4ee… 4b5e66fa… P39         14600
+#>  3 76_1  SeuratProject               15.5                 1759 bTlx!HK=oS         842c6f5d-4a94-4ee… 52ab9222… P58         14600
+#>  4 77_1  SeuratProject               15.4                 2434 E4g5+)v;AV         842c6f5d-4a94-4ee… 52ab9222… P58         14600
+#>  5 78_1  SeuratProject               15.3                 1798 +q?29B%2nH         842c6f5d-4a94-4ee… 52ab9222… P58         14600
+#>  6 79_1  SeuratProject               15.4                 1595 zuJ#MBMWy;         842c6f5d-4a94-4ee… 52ab9222… P58         14600
+#>  7 1_1   SeuratProject               15.3                 3493 I8a42<8st4         842c6f5d-4a94-4ee… 184fa234… P65         14600
+#>  8 80_1  SeuratProject               15.5                 1837 zz-!e5_XAo         842c6f5d-4a94-4ee… 1de3f3ba… P58         14600
+#>  9 81_1  SeuratProject               15.2                 2082 -mb&DWckf(         842c6f5d-4a94-4ee… 1de3f3ba… P58         14600
+#> 10 72_1  SeuratProject               18.0                 2642 8wGs7JgUjj         842c6f5d-4a94-4ee… 6b194412… P39         14600
+#> # ℹ 2,796 more rows
+#> # ℹ 50 more variables: tissue_groups <chr>, nFeature_expressed_in_sample <int>, nCount_RNA <dbl>, empty_droplet <lgl>,
+#> #   cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>, subsets_Ribo_percent <int>,
+#> #   high_mitochondrion <lgl>, high_ribosome <lgl>, alive <lgl>, scDblFinder.class <chr>, file_id_cellNexus_single_cell <chr>,
+#> #   file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>, inverse_transform <chr>,
+#> #   cell_annotation_blueprint_singler <chr>, cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>,
+#> #   ethnicity_flagging_score <dbl>, low_confidence_ethnicity <chr>, .aggregated_cells <int>, imputed_ethnicity <chr>, …
 ```
 
 By default, data is downloaded to `get_default_cache_dir()` output. If memory is a concern, users can specify a custom path to metadata and counts `cache_directory` argument. 
@@ -764,25 +667,28 @@ get_metadata(
   dplyr::filter(file_id_cellNexus_single_cell %in% c(file_id_from_cloud, file_id_local)) |>
   dplyr::select(cell_id, sample_id, dataset_id, cell_type_unified_ensemble, atlas_id, file_id_cellNexus_single_cell) |>
   get_single_cell_experiment(cache_directory = local_cache)
-#> â„¹ Realising metadata.
-#> â„¹ Synchronising files
-#> â„¹ Reading files.
-#> â„¹ Compiling Experiment.
-#> # A SingleCellExperiment-tibble abstraction: 500 Ã— 7
-#> # [90mFeatures=13132 | Cells=500 | Assays=counts[0m
-#>    .cell            sample_id dataset_id cell_type_unified_ensemble atlas_id             file_id_cellNexus_single_cell         original_cell_
-#>    <chr>            <chr>     <chr>      <chr>                      <chr>                <chr>                                 <chr>         
-#>  1 AAACATACAACCAC_1 pbmc3k    pbmc3k     Memory CD4 T               cellxgene/03-10-2025 67e196a3c4e145151fc9e06c200e2f7f.h5ad AAACATACAACCAC
-#>  2 AAACATTGAGCTAC_1 pbmc3k    pbmc3k     B                          cellxgene/03-10-2025 67e196a3c4e145151fc9e06c200e2f7f.h5ad AAACATTGAGCTAC
-#>  3 AAACATTGATCAGC_1 pbmc3k    pbmc3k     Memory CD4 T               cellxgene/03-10-2025 67e196a3c4e145151fc9e06c200e2f7f.h5ad AAACATTGATCAGC
-#>  4 AAACCGTGCTTCCG_1 pbmc3k    pbmc3k     CD14+ Mono                 cellxgene/03-10-2025 67e196a3c4e145151fc9e06c200e2f7f.h5ad AAACCGTGCTTCCG
-#>  5 AAACCGTGTATGCG_1 pbmc3k    pbmc3k     NK                         cellxgene/03-10-2025 67e196a3c4e145151fc9e06c200e2f7f.h5ad AAACCGTGTATGCG
-#>  6 AAACGCACTGGTAC_1 pbmc3k    pbmc3k     Memory CD4 T               cellxgene/03-10-2025 67e196a3c4e145151fc9e06c200e2f7f.h5ad AAACGCACTGGTAC
-#>  7 AAACGCTGACCAGT_1 pbmc3k    pbmc3k     CD8 T                      cellxgene/03-10-2025 67e196a3c4e145151fc9e06c200e2f7f.h5ad AAACGCTGACCAGT
-#>  8 AAACGCTGGTTCTT_1 pbmc3k    pbmc3k     CD8 T                      cellxgene/03-10-2025 67e196a3c4e145151fc9e06c200e2f7f.h5ad AAACGCTGGTTCTT
-#>  9 AAACGCTGTAGCCA_1 pbmc3k    pbmc3k     Naive CD4 T                cellxgene/03-10-2025 67e196a3c4e145151fc9e06c200e2f7f.h5ad AAACGCTGTAGCCA
-#> 10 AAACGCTGTTTCTG_1 pbmc3k    pbmc3k     FCGR3A+ Mono               cellxgene/03-10-2025 67e196a3c4e145151fc9e06c200e2f7f.h5ad AAACGCTGTTTCTG
-#> # â„¹ 490 more rows
+#> ℹ Downloading 1 file, totalling 0 GB
+#> ℹ Downloading https://object-store.rc.nectar.org.au/v1/AUTH_06d6e008e3e642da99d806ba3ea629c5/cellNexus-metadata/sample_hca2024_v2.3.2.parquet to /vast/scratch/users/shen.m/tmp/RtmpE4YcCe/sample_hca2024_v2.3.2.parquet
+#> ℹ Realising metadata.
+#> ℹ Synchronising files
+#> ℹ Reading files.
+#> ℹ Compiling Experiment.
+#> # A SingleCellExperiment-tibble abstraction: 500 × 7
+#> # [90mFeatures=13132 | Cells=500 | Assays=counts[0m
+#>    .cell            sample_id dataset_id cell_type_unified_ensemble atlas_id             file_id_cellNexus_sing…¹ original_cell_
+#>    <chr>            <chr>     <chr>      <chr>                      <chr>                <chr>                    <chr>         
+#>  1 AAACATACAACCAC_1 pbmc3k    pbmc3k     Memory CD4 T               cellxgene/03-10-2025 67e196a3c4e145151fc9e06… AAACATACAACCAC
+#>  2 AAACATTGAGCTAC_1 pbmc3k    pbmc3k     B                          cellxgene/03-10-2025 67e196a3c4e145151fc9e06… AAACATTGAGCTAC
+#>  3 AAACATTGATCAGC_1 pbmc3k    pbmc3k     Memory CD4 T               cellxgene/03-10-2025 67e196a3c4e145151fc9e06… AAACATTGATCAGC
+#>  4 AAACCGTGCTTCCG_1 pbmc3k    pbmc3k     CD14+ Mono                 cellxgene/03-10-2025 67e196a3c4e145151fc9e06… AAACCGTGCTTCCG
+#>  5 AAACCGTGTATGCG_1 pbmc3k    pbmc3k     NK                         cellxgene/03-10-2025 67e196a3c4e145151fc9e06… AAACCGTGTATGCG
+#>  6 AAACGCACTGGTAC_1 pbmc3k    pbmc3k     Memory CD4 T               cellxgene/03-10-2025 67e196a3c4e145151fc9e06… AAACGCACTGGTAC
+#>  7 AAACGCTGACCAGT_1 pbmc3k    pbmc3k     CD8 T                      cellxgene/03-10-2025 67e196a3c4e145151fc9e06… AAACGCTGACCAGT
+#>  8 AAACGCTGGTTCTT_1 pbmc3k    pbmc3k     CD8 T                      cellxgene/03-10-2025 67e196a3c4e145151fc9e06… AAACGCTGGTTCTT
+#>  9 AAACGCTGTAGCCA_1 pbmc3k    pbmc3k     Naive CD4 T                cellxgene/03-10-2025 67e196a3c4e145151fc9e06… AAACGCTGTAGCCA
+#> 10 AAACGCTGTTTCTG_1 pbmc3k    pbmc3k     FCGR3A+ Mono               cellxgene/03-10-2025 67e196a3c4e145151fc9e06… AAACGCTGTTTCTG
+#> # ℹ 490 more rows
+#> # ℹ abbreviated name: ¹​file_id_cellNexus_single_cell
 ```
 
 # Cell metadata
@@ -818,9 +724,9 @@ sessionInfo()
 #> LAPACK: /stornext/System/data/software/rhel/9/base/tools/R/4.5.3/lib64/R/lib/libRlapack.so;  LAPACK version 3.12.1
 #> 
 #> locale:
-#>  [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C               LC_TIME=en_US.UTF-8        LC_COLLATE=en_US.UTF-8     LC_MONETARY=en_US.UTF-8   
-#>  [6] LC_MESSAGES=en_US.UTF-8    LC_PAPER=en_US.UTF-8       LC_NAME=C                  LC_ADDRESS=C               LC_TELEPHONE=C            
-#> [11] LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C       
+#>  [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C               LC_TIME=en_US.UTF-8        LC_COLLATE=en_US.UTF-8    
+#>  [5] LC_MONETARY=en_US.UTF-8    LC_MESSAGES=en_US.UTF-8    LC_PAPER=en_US.UTF-8       LC_NAME=C                 
+#>  [9] LC_ADDRESS=C               LC_TELEPHONE=C             LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C       
 #> 
 #> time zone: Australia/Melbourne
 #> tzcode source: system (glibc)
@@ -829,47 +735,102 @@ sessionInfo()
 #> [1] stats4    stats     graphics  grDevices utils     datasets  methods   base     
 #> 
 #> other attached packages:
-#>  [1] BiocStyle_2.38.0            RcppSpdlog_0.0.28           ggplot2_4.0.2               SummarizedExperiment_1.40.0 Biobase_2.70.0             
-#>  [6] GenomicRanges_1.62.1        Seqinfo_1.0.0               IRanges_2.44.0              S4Vectors_0.49.1-1          BiocGenerics_0.56.0        
-#> [11] generics_0.1.4              MatrixGenerics_1.22.0       matrixStats_1.5.0           shiny_1.13.0                anndataR_1.0.2             
-#> [16] cellNexus_0.99.27           testthat_3.3.2              dplyr_1.2.1                
+#>  [1] cellNexus_0.99.30               RcppSpdlog_0.0.28               purrr_1.2.2                    
+#>  [4] HPCell_0.6.0                    ggplot2_4.0.2                   tidyr_1.3.2                    
+#>  [7] tidySingleCellExperiment_1.20.1 ttservice_0.5.3                 SingleCellExperiment_1.32.0    
+#> [10] anndataR_1.3.1                  arrow_23.0.1.2                  SummarizedExperiment_1.40.0    
+#> [13] Biobase_2.70.0                  GenomicRanges_1.62.1            Seqinfo_1.0.0                  
+#> [16] IRanges_2.44.0                  S4Vectors_0.49.1-1              BiocGenerics_0.56.0            
+#> [19] generics_0.1.4                  MatrixGenerics_1.22.0           matrixStats_1.5.0              
+#> [22] dplyr_1.2.1                    
 #> 
 #> loaded via a namespace (and not attached):
-#>   [1] fs_2.0.1                        spatstat.sparse_3.1-0           fontawesome_0.5.3               devtools_2.5.0                  httr_1.4.8                     
-#>   [6] RColorBrewer_1.1-3              tools_4.5.3                     sctransform_0.4.3               backports_1.5.1                 utf8_1.2.6                     
-#>  [11] R6_2.6.1                        DT_0.34.0                       HDF5Array_1.38.0                lazyeval_0.2.3                  uwot_0.2.4                     
-#>  [16] rhdf5filters_1.22.0             withr_3.0.2                     sp_2.2-1                        gridExtra_2.3                   nanoarrow_0.8.0                
-#>  [21] progressr_0.19.0                cli_3.6.6                       spatstat.explore_3.8-0          fastDummies_1.7.5               sass_0.4.10                    
-#>  [26] Seurat_5.5.0.9002               arrow_23.0.1.2                  S7_0.2.1-1                      spatstat.data_3.1-9             ggridges_0.5.7                 
-#>  [31] pbapply_1.7-4                   commonmark_2.0.0                R.utils_2.13.0                  parallelly_1.46.1               sessioninfo_1.2.3              
-#>  [36] rstudioapi_0.18.0               ica_1.0-3                       spatstat.random_3.4-5           Matrix_1.7-4                    fansi_1.0.7                    
-#>  [41] waldo_0.6.2                     rclipboard_0.2.1                abind_1.4-8                     R.methodsS3_1.8.2               lifecycle_1.0.5                
-#>  [46] yaml_2.3.12                     rhdf5_2.54.1                    SparseArray_1.10.10             Rtsne_0.17                      grid_4.5.3                     
-#>  [51] blob_1.3.0                      promises_1.5.0                  dir.expiry_1.18.0               miniUI_0.1.2                    lattice_0.22-9                 
-#>  [56] cowplot_1.2.0                   pillar_1.11.1                   knitr_1.51                      future.apply_1.20.2             codetools_0.2-20               
-#>  [61] glue_1.8.0                      tiledb_0.33.1                   spatstat.univar_3.1-7           data.table_1.18.2.1             tidySingleCellExperiment_1.20.1
-#>  [66] vctrs_0.7.3                     png_0.1-9                       spam_2.11-3                     gtable_0.3.6                    aws.s3_0.3.22                  
-#>  [71] assertthat_0.2.1                cachem_1.1.0                    xfun_0.57                       S4Arrays_1.10.1                 mime_0.13                      
-#>  [76] rsconnect_1.8.0                 survival_3.8-6                  SingleCellExperiment_1.32.0     ellipsis_0.3.3                  fitdistrplus_1.2-6             
-#>  [81] ROCR_1.0-12                     tiledbsoma_2.1.2                nlme_3.1-168                    RcppCCTZ_0.2.14                 usethis_3.2.1                  
-#>  [86] bit64_4.6.0-1                   filelock_1.0.3                  RcppAnnoy_0.0.23                GenomeInfoDb_1.46.2             rprojroot_2.1.1                
-#>  [91] R.cache_0.17.0                  bslib_0.10.0                    irlba_2.3.7                     KernSmooth_2.23-26              otel_0.2.0                     
-#>  [96] DBI_1.3.0                       zellkonverter_1.20.1            duckdb_1.4.3                    tidyselect_1.2.1                cellxgene.census_1.16.1        
-#> [101] bit_4.6.0                       compiler_4.5.3                  curl_7.0.0                      rjsoncons_1.3.2                 h5mread_1.2.1                  
-#> [106] xml2_1.5.2                      nanotime_0.3.13                 desc_1.4.3                      DelayedArray_0.36.1             plotly_4.12.0                  
-#> [111] bookdown_0.46                   checkmate_2.3.4                 scales_1.4.0                    lmtest_0.9-40                   spdl_0.0.5                     
-#> [116] stringr_1.6.0                   digest_0.6.39                   goftest_1.2-3                   spatstat.utils_3.2-2            rmarkdown_2.31                 
-#> [121] basilisk_1.22.0                 XVector_0.50.0                  htmltools_0.5.9                 pkgconfig_2.0.3                 base64enc_0.1-6                
-#> [126] dbplyr_2.5.2                    fastmap_1.2.0                   rlang_1.2.0                     htmlwidgets_1.6.4               UCSC.utils_1.6.1               
-#> [131] farver_2.1.2                    jquerylib_0.1.4                 zoo_1.8-15                      jsonlite_2.0.0                  R.oo_1.27.1                    
-#> [136] magrittr_2.0.5                  dotCall64_1.2                   patchwork_1.3.2                 Rhdf5lib_1.32.0                 Rcpp_1.1.1-1                   
-#> [141] reticulate_1.46.0               stringi_1.8.7                   brio_1.1.5                      MASS_7.3-65                     plyr_1.8.9                     
-#> [146] pkgbuild_1.4.8                  parallel_4.5.3                  listenv_0.10.1                  ggrepel_0.9.8                   forcats_1.0.1                  
-#> [151] deldir_2.0-4                    splines_4.5.3                   tensor_1.5.1                    igraph_2.2.3                    cellxgenedp_1.14.0             
-#> [156] spatstat.geom_3.7-3             RcppHNSW_0.6.0                  reshape2_1.4.5                  pkgload_1.5.1                   ttservice_0.5.3                
-#> [161] evaluate_1.0.5                  SeuratObject_5.4.0              BiocManager_1.30.27             httpuv_1.6.17                   RANN_2.6.2                     
-#> [166] tidyr_1.3.2                     purrr_1.2.2                     polyclip_1.10-7                 future_1.70.0                   scattermore_1.2                
-#> [171] xtable_1.8-8                    RSpectra_0.16-2                 roxygen2_7.3.3                  later_1.4.8                     viridisLite_0.4.3              
-#> [176] tibble_3.3.1                    memoise_2.0.1                   aws.signature_0.6.0             cluster_2.1.8.2                 shinyWidgets_0.9.1             
-#> [181] globals_0.19.1
+#>   [1] igraph_2.2.3                    ica_1.0-3                       plotly_4.12.0                  
+#>   [4] SingleR_2.12.0                  scater_1.38.1                   devtools_2.5.0                 
+#>   [7] tidyselect_1.2.1                bit_4.6.0                       lattice_0.22-9                 
+#>  [10] rjson_0.2.21                    blob_1.3.0                      stringr_1.6.0                  
+#>  [13] S4Arrays_1.10.1                 rclipboard_0.2.1                parallel_4.5.3                 
+#>  [16] png_0.1-9                       cli_3.6.6                       ProtGenerics_1.42.0            
+#>  [19] askpass_1.2.1                   openssl_2.4.2                   goftest_1.2-3                  
+#>  [22] BiocIO_1.20.0                   bluster_1.20.0                  BiocNeighbors_2.4.0            
+#>  [25] tarchetypes_0.14.1              uwot_0.2.4                      curl_7.0.0                     
+#>  [28] mime_0.13                       evaluate_1.0.5                  stringi_1.8.7                  
+#>  [31] ids_1.0.1                       backports_1.5.1                 desc_1.4.3                     
+#>  [34] XML_3.99-0.23                   httpuv_1.6.17                   AnnotationDbi_1.72.0           
+#>  [37] magrittr_2.0.5                  rappdirs_0.3.4                  splines_4.5.3                  
+#>  [40] nanonext_1.8.2                  aws.signature_0.6.0             DT_0.34.0                      
+#>  [43] sctransform_0.4.3               ggbeeswarm_0.7.3                sessioninfo_1.2.3              
+#>  [46] DBI_1.3.0                       HDF5Array_1.38.0                jquerylib_0.1.4                
+#>  [49] withr_3.0.2                     reformulas_0.4.4                rprojroot_2.1.1                
+#>  [52] xgboost_3.2.1.1                 tidySummarizedExperiment_1.20.1 lmtest_0.9-40                  
+#>  [55] brio_1.1.5                      BiocManager_1.30.27             rtracklayer_1.70.1             
+#>  [58] duckdb_1.4.3                    htmlwidgets_1.6.4               fs_2.0.1                       
+#>  [61] biomaRt_2.66.2                  ggrepel_0.9.8                   SparseArray_1.10.10            
+#>  [64] tidyseurat_0.8.10               h5mread_1.2.1                   reticulate_1.46.0              
+#>  [67] zoo_1.8-15                      tiledbsoma_2.1.2                XVector_0.50.0                 
+#>  [70] knitr_1.51                      RcppCCTZ_0.2.14                 UCSC.utils_1.6.1               
+#>  [73] secretbase_1.2.1                fansi_1.0.7                     patchwork_1.3.2                
+#>  [76] pak_0.11.1                      grid_4.5.3                      data.table_1.18.2.1            
+#>  [79] rhdf5_2.54.1                    R.oo_1.27.1                     RSpectra_0.16-2                
+#>  [82] irlba_2.3.7                     tiledb_0.33.1                   commonmark_2.0.0               
+#>  [85] fastDummies_1.7.5               ellipsis_0.3.3                  base64url_1.4                  
+#>  [88] lazyeval_0.2.3                  yaml_2.3.12                     conflicted_1.2.0               
+#>  [91] survival_3.8-6                  scattermore_1.2                 crayon_1.5.3                   
+#>  [94] mirai_2.6.1                     RcppAnnoy_0.0.23                RColorBrewer_1.1-3             
+#>  [97] progressr_0.19.0                later_1.4.8                     ggridges_0.5.7                 
+#> [100] codetools_0.2-20                base64enc_0.1-6                 tidybulk_2.1.0                 
+#> [103] Seurat_5.5.0.9002               KEGGREST_1.50.0                 Rtsne_0.17                     
+#> [106] limma_3.66.0                    Rsamtools_2.26.0                filelock_1.0.3                 
+#> [109] pkgconfig_2.0.3                 xml2_1.5.2                      spatstat.univar_3.1-7          
+#> [112] GenomicAlignments_1.46.0        spatstat.sparse_3.1-0           viridisLite_0.4.3              
+#> [115] xtable_1.8-8                    plyr_1.8.9                      httr_1.4.8                     
+#> [118] rbibutils_2.4.1                 tools_4.5.3                     globals_0.19.1                 
+#> [121] SeuratObject_5.4.0              pkgbuild_1.4.8                  beeswarm_0.4.0                 
+#> [124] checkmate_2.3.4                 nlme_3.1-168                    dbplyr_2.5.2                   
+#> [127] assertthat_0.2.1                lme4_2.0-1                      digest_0.6.39                  
+#> [130] Matrix_1.7-4                    dir.expiry_1.18.0               farver_2.1.2                   
+#> [133] tzdb_0.5.0                      AnnotationFilter_1.34.0         reshape2_1.4.5                 
+#> [136] viridis_0.6.5                   glue_1.8.0                      cachem_1.1.0                   
+#> [139] BiocFileCache_3.0.0             polyclip_1.10-7                 rjsoncons_1.3.2                
+#> [142] Biostrings_2.78.0               parallelly_1.46.1               aws.s3_0.3.22                  
+#> [145] pkgload_1.5.1                   statmod_1.5.1                   here_1.0.2                     
+#> [148] RcppHNSW_0.6.0                  ScaledMatrix_1.18.0             minqa_1.2.8                    
+#> [151] pbapply_1.7-4                   httr2_1.2.2                     job_0.3.1                      
+#> [154] spam_2.11-3                     dqrng_0.4.1                     utf8_1.2.6                     
+#> [157] scDblFinder_1.24.10             basilisk_1.22.0                 crew_1.3.0                     
+#> [160] gridExtra_2.3                   shiny_1.13.0                    R.utils_2.13.0                 
+#> [163] rhdf5filters_1.22.0             RCurl_1.98-1.18                 memoise_2.0.1                  
+#> [166] rmarkdown_2.31                  nanoarrow_0.8.0                 scales_1.4.0                   
+#> [169] R.methodsS3_1.8.2               future_1.70.0                   RANN_2.6.2                     
+#> [172] renv_1.2.1                      spatstat.data_3.1-9             rstudioapi_0.18.0              
+#> [175] cluster_2.1.8.2                 zellkonverter_1.20.1            spatstat.utils_3.2-2           
+#> [178] hms_1.1.4                       fitdistrplus_1.2-6              cowplot_1.2.0                  
+#> [181] rlang_1.2.0                     GenomeInfoDb_1.46.2             crew.cluster_0.4.0             
+#> [184] DelayedMatrixStats_1.32.0       sparseMatrixStats_1.22.0        shinyWidgets_0.9.1             
+#> [187] dotCall64_1.2                   scuttle_1.20.0                  xfun_0.57                      
+#> [190] abind_1.4-8                     spdl_0.0.5                      tibble_3.3.1                   
+#> [193] EnsDb.Hsapiens.v86_2.99.0       Rhdf5lib_1.32.0                 readr_2.2.0                    
+#> [196] bitops_1.0-9                    Rdpack_2.6.6                    ps_1.9.2                       
+#> [199] promises_1.5.0                  RSQLite_2.4.6                   cellxgenedp_1.14.0             
+#> [202] DelayedArray_0.36.1             proxy_0.4-29                    compiler_4.5.3                 
+#> [205] forcats_1.0.1                   prettyunits_1.2.0               boot_1.3-32                    
+#> [208] beachmat_2.26.0                 listenv_0.10.1                  Rcpp_1.1.1-1                   
+#> [211] edgeR_4.8.2                     roxygen2_7.3.3                  BiocSingular_1.26.1            
+#> [214] tensor_1.5.1                    usethis_3.2.1                   MASS_7.3-65                    
+#> [217] progress_1.2.3                  uuid_1.2-2                      BiocParallel_1.44.0            
+#> [220] ggupset_0.4.1                   nanotime_0.3.13                 spatstat.random_3.4-5          
+#> [223] R6_2.6.1                        fastmap_1.2.0                   vipor_0.4.7                    
+#> [226] ensembldb_2.34.0                ROCR_1.0-12                     targets_1.12.0                 
+#> [229] rsvd_1.0.5                      gtable_0.3.6                    KernSmooth_2.23-26             
+#> [232] miniUI_0.1.2                    deldir_2.0-4                    htmltools_0.5.9                
+#> [235] bit64_4.6.0-1                   spatstat.explore_3.8-0          lifecycle_1.0.5                
+#> [238] S7_0.2.1-1                      processx_3.8.7                  nloptr_2.2.1                   
+#> [241] callr_3.7.6                     restfulr_0.0.16                 sass_0.4.10                    
+#> [244] vctrs_0.7.3                     testthat_3.3.2                  rsconnect_1.10.1               
+#> [247] spatstat.geom_3.7-3             scran_1.38.1                    sp_2.2-1                       
+#> [250] future.apply_1.20.2             bslib_0.10.0                    pillar_1.11.1                  
+#> [253] GenomicFeatures_1.62.0          DropletUtils_1.30.0             cellxgene.census_1.16.1        
+#> [256] collections_0.3.12              metapod_1.18.0                  locfit_1.5-9.12                
+#> [259] otel_0.2.0                      BiocStyle_2.38.0                jsonlite_2.0.0                 
+#> [262] cigarillo_1.0.0
 ```

--- a/vignettes/gene-expression-explore.Rmd
+++ b/vignettes/gene-expression-explore.Rmd
@@ -18,12 +18,11 @@ This page focuses on expression-layer retrieval workflows after metadata filteri
 
 ``` r
 library(cellNexus)
-#> Registered S3 method overwritten by 'zellkonverter':
-#>   method                                             from      
-#>   py_to_r.pandas.core.arrays.categorical.Categorical reticulate
 library(dplyr)
 
 metadata <- get_metadata(cloud_metadata = SAMPLE_DATABASE_URL)
+#> ℹ Downloading 1 file, totalling 0 GB
+#> ℹ Downloading https://object-store.rc.nectar.org.au/v1/AUTH_06d6e008e3e642da99d806ba3ea629c5/cellNexus-metadata/sample_hca2024_v2.3.2.parquet to /vast/scratch/users/shen.m/r_cache/R/cellNexus/sample_hca2024_v2.3.2.parquet
 metadata <- metadata |>
   keep_quality_cells()
 ```
@@ -40,30 +39,30 @@ query_metadata <- metadata |>
     imputed_ethnicity == "African American"
   )
 query_metadata  
-#> # Source:   SQL [?? x 76]
-#> # Database: DuckDB v1.2.2 [shen.m@Darwin 23.6.0:R 4.5.0/:memory:]
-#>    cell_id observation_joinid dataset_id         sample_id sample_ experiment___
-#>      <dbl> <chr>              <chr>              <chr>     <chr>   <chr>        
-#>  1      16 j}0<Y>a#X~         842c6f5d-4a94-4ee… 1119f482… 1119f4… ""           
-#>  2      19 lNmuO5xs~3         842c6f5d-4a94-4ee… 1119f482… 1119f4… ""           
-#>  3      14 qxl7HJjL$L         842c6f5d-4a94-4ee… 1119f482… 1119f4… ""           
-#>  4       2 $jvBt8wHSK         842c6f5d-4a94-4ee… 1f755b9b… 1f755b… ""           
-#>  5      21 Mq^|(c<-#3         842c6f5d-4a94-4ee… b0d0c16e… b0d0c1… ""           
-#>  6      24 I`4{4__f#J         842c6f5d-4a94-4ee… b0d0c16e… b0d0c1… ""           
-#>  7      22 %vkLP;!cqY         842c6f5d-4a94-4ee… b0d0c16e… b0d0c1… ""           
-#>  8      11 gncTL3)pV~         842c6f5d-4a94-4ee… bd5f6876… bd5f68… ""           
-#>  9      25 rfOnkhfWl8         842c6f5d-4a94-4ee… 04e410cb… 04e410… ""           
-#> 10      24 =tj7A<!2TZ         842c6f5d-4a94-4ee… 04e410cb… 04e410… ""           
-#> 11      13 Py{Fqs?~!!         842c6f5d-4a94-4ee… 30ea4b4f… 30ea4b… ""           
-#> 12       9 s$u5u14ye$         842c6f5d-4a94-4ee… 49ef9551… 49ef95… ""           
-#> 13       6 ?y4kdGGQ!^         842c6f5d-4a94-4ee… 49ef9551… 49ef95… ""           
-#> # ℹ 70 more variables: run_from_cell_id <chr>, sample_heuristic <chr>,
-#> #   age_days <int>, tissue_groups <chr>, nFeature_expressed_in_sample <int>,
-#> #   nCount_RNA <dbl>, empty_droplet <lgl>, cell_type_unified_ensemble <chr>,
-#> #   is_immune <lgl>, subsets_Mito_percent <int>, subsets_Ribo_percent <int>,
-#> #   high_mitochondrion <lgl>, high_ribosome <lgl>, scDblFinder.class <chr>,
-#> #   sample_chunk <int>, cell_chunk <int>, sample_pseudobulk_chunk <int>,
-#> #   file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>, …
+#> # Source:   SQL [?? x 29]
+#> # Database: DuckDB 1.4.3 [unknown@Linux 5.14.0-570.123.1.el9_6.x86_64:R 4.5.3/:memory:]
+#>    cell_id dataset_id    sample_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA empty_droplet cell_type_unified_en…²
+#>      <dbl> <chr>         <chr>        <int> <chr>                          <int>      <dbl> <lgl>         <chr>                 
+#>  1      19 842c6f5d-4a9… 1119f482…    14600 breast                          1876       9.15 FALSE         cd16 mono             
+#>  2      14 842c6f5d-4a9… 1119f482…    14600 breast                          1547      10.5  FALSE         cd16 mono             
+#>  3      16 842c6f5d-4a9… 1119f482…    14600 breast                          2438       9.80 FALSE         cd16 mono             
+#>  4       2 842c6f5d-4a9… 1f755b9b…    14600 breast                          1342       9.40 FALSE         cd16 mono             
+#>  5      24 842c6f5d-4a9… b0d0c16e…    14600 breast                          1800      10.7  FALSE         cd16 mono             
+#>  6      22 842c6f5d-4a9… b0d0c16e…    14600 breast                          1759      11.1  FALSE         cd16 mono             
+#>  7      21 842c6f5d-4a9… b0d0c16e…    14600 breast                          1552      10.2  FALSE         cd16 mono             
+#>  8      11 842c6f5d-4a9… bd5f6876…    14600 breast                           399      11.2  FALSE         cd16 mono             
+#>  9      25 842c6f5d-4a9… 04e410cb…    14600 breast                          1324      13.0  FALSE         cd16 mono             
+#> 10      24 842c6f5d-4a9… 04e410cb…    14600 breast                          1254      13.8  FALSE         cd16 mono             
+#> 11      13 842c6f5d-4a9… 30ea4b4f…    14600 breast                          1368      11.0  FALSE         cd16 mono             
+#> 12       6 842c6f5d-4a9… 49ef9551…    14600 breast                          1771      11.6  FALSE         cd16 mono             
+#> 13       9 842c6f5d-4a9… 49ef9551…    14600 breast                          1767      12.3  FALSE         cd16 mono             
+#> # ℹ abbreviated names: ¹​nFeature_expressed_in_sample, ²​cell_type_unified_ensemble
+#> # ℹ 20 more variables: is_immune <lgl>, subsets_Mito_percent <int>, subsets_Ribo_percent <int>, high_mitochondrion <lgl>,
+#> #   high_ribosome <lgl>, alive <lgl>, scDblFinder.class <chr>, file_id_cellNexus_single_cell <chr>,
+#> #   file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>, inverse_transform <chr>,
+#> #   cell_annotation_blueprint_singler <chr>, cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>,
+#> #   ethnicity_flagging_score <dbl>, low_confidence_ethnicity <chr>, .aggregated_cells <int>, imputed_ethnicity <chr>,
+#> #   atlas_id <chr>
 ```
 
 # Retrieve expression by representation
@@ -77,26 +76,32 @@ sce_counts <- query_metadata |>
 #> ℹ Realising metadata.
 #> ℹ Synchronising files
 #> ℹ Reading files.
-#> For native R and reading and writing of H5AD files, an R <AnnData> object, and conversion to <SingleCellExperiment> or <Seurat> objects, check out the anndataR package:
-#> ℹ Install it from Bioconductor with `BiocManager::install("anndataR")`
-#> ℹ See more at <https://bioconductor.org/packages/anndataR/>
-#> ℹ Compiling Experiment.
-#> 
-#> This message is displayed once per session.
+#> Reading counts ■■■■■■■■■■■■■■■■                  50% | ETA:  1s                                                                ℹ Compiling Experiment.
 sce_counts
-#> class: SingleCellExperiment 
-#> dim: 33145 13 
-#> metadata(0):
-#> assays(1): counts
-#> rownames(33145): ENSG00000243485 ENSG00000237613 ... ENSG00000277475
-#>   ENSG00000268674
-#> rowData names(0):
-#> colnames(13): 16_1 19_1 ... 9_2 6_2
-#> colData names(76): observation_joinid dataset_id ...
-#>   tissue_ontology_term_id original_cell_
-#> reducedDimNames(0):
-#> mainExpName: NULL
-#> altExpNames(0):
+#> # A SingleCellExperiment-tibble abstraction: 13 × 30
+#> # [90mFeatures=33145 | Cells=13 | Assays=counts[0m
+#>    .cell dataset_id      sample_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA empty_droplet cell_type_unified_en…²
+#>    <chr> <chr>           <chr>        <int> <chr>                          <int>      <dbl> <lgl>         <chr>                 
+#>  1 19_1  842c6f5d-4a94-… 1119f482…    14600 breast                          1876       9.15 FALSE         cd16 mono             
+#>  2 14_1  842c6f5d-4a94-… 1119f482…    14600 breast                          1547      10.5  FALSE         cd16 mono             
+#>  3 16_1  842c6f5d-4a94-… 1119f482…    14600 breast                          2438       9.80 FALSE         cd16 mono             
+#>  4 2_1   842c6f5d-4a94-… 1f755b9b…    14600 breast                          1342       9.40 FALSE         cd16 mono             
+#>  5 24_1  842c6f5d-4a94-… b0d0c16e…    14600 breast                          1800      10.7  FALSE         cd16 mono             
+#>  6 22_1  842c6f5d-4a94-… b0d0c16e…    14600 breast                          1759      11.1  FALSE         cd16 mono             
+#>  7 21_1  842c6f5d-4a94-… b0d0c16e…    14600 breast                          1552      10.2  FALSE         cd16 mono             
+#>  8 11_1  842c6f5d-4a94-… bd5f6876…    14600 breast                           399      11.2  FALSE         cd16 mono             
+#>  9 25_2  842c6f5d-4a94-… 04e410cb…    14600 breast                          1324      13.0  FALSE         cd16 mono             
+#> 10 24_2  842c6f5d-4a94-… 04e410cb…    14600 breast                          1254      13.8  FALSE         cd16 mono             
+#> 11 13_2  842c6f5d-4a94-… 30ea4b4f…    14600 breast                          1368      11.0  FALSE         cd16 mono             
+#> 12 6_2   842c6f5d-4a94-… 49ef9551…    14600 breast                          1771      11.6  FALSE         cd16 mono             
+#> 13 9_2   842c6f5d-4a94-… 49ef9551…    14600 breast                          1767      12.3  FALSE         cd16 mono             
+#> # ℹ abbreviated names: ¹​nFeature_expressed_in_sample, ²​cell_type_unified_ensemble
+#> # ℹ 21 more variables: is_immune <lgl>, subsets_Mito_percent <int>, subsets_Ribo_percent <int>, high_mitochondrion <lgl>,
+#> #   high_ribosome <lgl>, alive <lgl>, scDblFinder.class <chr>, file_id_cellNexus_single_cell <chr>,
+#> #   file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>, inverse_transform <chr>,
+#> #   cell_annotation_blueprint_singler <chr>, cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>,
+#> #   ethnicity_flagging_score <dbl>, low_confidence_ethnicity <chr>, .aggregated_cells <int>, imputed_ethnicity <chr>,
+#> #   atlas_id <chr>, original_cell_ <chr>
 ```
 
 ## Counts per million
@@ -107,24 +112,33 @@ sce_cpm <- query_metadata |>
   get_single_cell_experiment(assays = "cpm")
 #> ℹ Realising metadata.
 #> ℹ Synchronising files
-#> ℹ Downloading 1 file, totalling 0 GB
-#> ℹ Downloading https://object-store.rc.nectar.org.au/v1/AUTH_06d6e008e3e642da99d806ba3ea629c5/cellNexus-anndata/cellxgene_2024/0.2.1/cpm/001f82656d61ccb98f0ae26a2eb9e5ba___1.h5ad to /Users/shen.m/Library/Caches/org.R-project.R/R/cellNexus/cellxgene_2024/0.2.1//cpm/001f82656d61ccb98f0ae26a2eb9e5ba___1.h5ad
 #> ℹ Reading files.
 #> ℹ Compiling Experiment.
 sce_cpm
-#> class: SingleCellExperiment 
-#> dim: 33145 13 
-#> metadata(0):
-#> assays(1): cpm
-#> rownames(33145): ENSG00000243485 ENSG00000237613 ... ENSG00000277475
-#>   ENSG00000268674
-#> rowData names(0):
-#> colnames(13): 16_1 19_1 ... 9_2 6_2
-#> colData names(76): observation_joinid dataset_id ...
-#>   tissue_ontology_term_id original_cell_
-#> reducedDimNames(0):
-#> mainExpName: NULL
-#> altExpNames(0):
+#> # A SingleCellExperiment-tibble abstraction: 13 × 30
+#> # [90mFeatures=33145 | Cells=13 | Assays=cpm[0m
+#>    .cell dataset_id      sample_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA empty_droplet cell_type_unified_en…²
+#>    <chr> <chr>           <chr>        <int> <chr>                          <int>      <dbl> <lgl>         <chr>                 
+#>  1 19_1  842c6f5d-4a94-… 1119f482…    14600 breast                          1876       9.15 FALSE         cd16 mono             
+#>  2 14_1  842c6f5d-4a94-… 1119f482…    14600 breast                          1547      10.5  FALSE         cd16 mono             
+#>  3 16_1  842c6f5d-4a94-… 1119f482…    14600 breast                          2438       9.80 FALSE         cd16 mono             
+#>  4 2_1   842c6f5d-4a94-… 1f755b9b…    14600 breast                          1342       9.40 FALSE         cd16 mono             
+#>  5 24_1  842c6f5d-4a94-… b0d0c16e…    14600 breast                          1800      10.7  FALSE         cd16 mono             
+#>  6 22_1  842c6f5d-4a94-… b0d0c16e…    14600 breast                          1759      11.1  FALSE         cd16 mono             
+#>  7 21_1  842c6f5d-4a94-… b0d0c16e…    14600 breast                          1552      10.2  FALSE         cd16 mono             
+#>  8 11_1  842c6f5d-4a94-… bd5f6876…    14600 breast                           399      11.2  FALSE         cd16 mono             
+#>  9 25_2  842c6f5d-4a94-… 04e410cb…    14600 breast                          1324      13.0  FALSE         cd16 mono             
+#> 10 24_2  842c6f5d-4a94-… 04e410cb…    14600 breast                          1254      13.8  FALSE         cd16 mono             
+#> 11 13_2  842c6f5d-4a94-… 30ea4b4f…    14600 breast                          1368      11.0  FALSE         cd16 mono             
+#> 12 6_2   842c6f5d-4a94-… 49ef9551…    14600 breast                          1771      11.6  FALSE         cd16 mono             
+#> 13 9_2   842c6f5d-4a94-… 49ef9551…    14600 breast                          1767      12.3  FALSE         cd16 mono             
+#> # ℹ abbreviated names: ¹​nFeature_expressed_in_sample, ²​cell_type_unified_ensemble
+#> # ℹ 21 more variables: is_immune <lgl>, subsets_Mito_percent <int>, subsets_Ribo_percent <int>, high_mitochondrion <lgl>,
+#> #   high_ribosome <lgl>, alive <lgl>, scDblFinder.class <chr>, file_id_cellNexus_single_cell <chr>,
+#> #   file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>, inverse_transform <chr>,
+#> #   cell_annotation_blueprint_singler <chr>, cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>,
+#> #   ethnicity_flagging_score <dbl>, low_confidence_ethnicity <chr>, .aggregated_cells <int>, imputed_ethnicity <chr>,
+#> #   atlas_id <chr>, original_cell_ <chr>
 ```
 
 ## Pseudobulk
@@ -135,27 +149,25 @@ pb_counts <- query_metadata |>
   get_pseudobulk()
 #> ℹ Realising metadata.
 #> ℹ Synchronising files
-#> ℹ Downloading 1 file, totalling 0.26 GB
-#> ℹ Downloading https://object-store.rc.nectar.org.au/v1/AUTH_06d6e008e3e642da99d806ba3ea629c5/cellNexus-anndata/cellxgene_2024/0.2.1/pseudobulk/counts/91acbf94110b95b1e994fdb1e1322fd1___1.h5ad to /Users/shen.m/Library/Caches/org.R-project.R/R/cellNexus/cellxgene_2024/0.2.1/pseudobulk/counts/91acbf94110b95b1e994fdb1e1322fd1___1.h5ad
 #> ℹ Reading files.
 #> ℹ Compiling Experiment.
 pb_counts
-#> class: SingleCellExperiment 
-#> dim: 33145 7 
-#> metadata(0):
-#> assays(1): counts
-#> rownames(33145): ENSG00000243485 ENSG00000237613 ... ENSG00000277475
-#>   ENSG00000268674
-#> rowData names(0):
-#> colnames(7): 1119f4825edbcfb74341b89d9dec4ac8___cd16 mono
-#>   1f755b9b59313f6c5e80caa696799ac2___cd16 mono ...
-#>   30ea4b4f8922b4a6b35bf1a12be2d5e9___cd16 mono
-#>   49ef9551c2ddf79b01c74f863ea6f556___cd16 mono
-#> colData names(59): dataset_id sample_id ... tissue_ontology_term_id
-#>   sample_identifier
-#> reducedDimNames(0):
-#> mainExpName: NULL
-#> altExpNames(0):
+#> # A SingleCellExperiment-tibble abstraction: 7 × 25
+#> # [90mFeatures=33145 | Cells=7 | Assays=counts[0m
+#>   .cell      sample_id cell_type_unified_en…¹ dataset_id age_days tissue_groups empty_droplet is_immune high_mitochondrion alive
+#>   <chr>      <chr>     <chr>                  <chr>         <int> <chr>         <lgl>         <lgl>     <lgl>              <lgl>
+#> 1 1119f4825… 1119f482… cd16 mono              842c6f5d-…    14600 breast        FALSE         TRUE      FALSE              TRUE 
+#> 2 1f755b9b5… 1f755b9b… cd16 mono              842c6f5d-…    14600 breast        FALSE         TRUE      FALSE              TRUE 
+#> 3 b0d0c16ed… b0d0c16e… cd16 mono              842c6f5d-…    14600 breast        FALSE         TRUE      FALSE              TRUE 
+#> 4 bd5f6876c… bd5f6876… cd16 mono              842c6f5d-…    14600 breast        FALSE         TRUE      FALSE              TRUE 
+#> 5 04e410cba… 04e410cb… cd16 mono              842c6f5d-…    14600 breast        FALSE         TRUE      FALSE              TRUE 
+#> 6 30ea4b4f8… 30ea4b4f… cd16 mono              842c6f5d-…    14600 breast        FALSE         TRUE      FALSE              TRUE 
+#> 7 49ef9551c… 49ef9551… cd16 mono              842c6f5d-…    14600 breast        FALSE         TRUE      FALSE              TRUE 
+#> # ℹ abbreviated name: ¹​cell_type_unified_ensemble
+#> # ℹ 15 more variables: scDblFinder.class <chr>, file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>,
+#> #   count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>, inverse_transform <chr>, cell_annotation_blueprint_singler <chr>,
+#> #   cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>,
+#> #   low_confidence_ethnicity <chr>, .aggregated_cells <int>, imputed_ethnicity <chr>, atlas_id <chr>, sample_identifier <chr>
 ```
 
 # Targeted gene queries
@@ -173,18 +185,30 @@ sce_gene <- query_metadata |>
 #> ℹ Reading files.
 #> ℹ Compiling Experiment.
 sce_gene
-#> class: SingleCellExperiment 
-#> dim: 1 13 
-#> metadata(0):
-#> assays(1): cpm
-#> rownames(1): ENSG00000134644
-#> rowData names(0):
-#> colnames(13): 16_1 19_1 ... 9_2 6_2
-#> colData names(76): observation_joinid dataset_id ...
-#>   tissue_ontology_term_id original_cell_
-#> reducedDimNames(0):
-#> mainExpName: NULL
-#> altExpNames(0):
+#> # A SingleCellExperiment-tibble abstraction: 13 × 30
+#> # [90mFeatures=1 | Cells=13 | Assays=cpm[0m
+#>    .cell dataset_id      sample_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA empty_droplet cell_type_unified_en…²
+#>    <chr> <chr>           <chr>        <int> <chr>                          <int>      <dbl> <lgl>         <chr>                 
+#>  1 19_1  842c6f5d-4a94-… 1119f482…    14600 breast                          1876       9.15 FALSE         cd16 mono             
+#>  2 14_1  842c6f5d-4a94-… 1119f482…    14600 breast                          1547      10.5  FALSE         cd16 mono             
+#>  3 16_1  842c6f5d-4a94-… 1119f482…    14600 breast                          2438       9.80 FALSE         cd16 mono             
+#>  4 2_1   842c6f5d-4a94-… 1f755b9b…    14600 breast                          1342       9.40 FALSE         cd16 mono             
+#>  5 24_1  842c6f5d-4a94-… b0d0c16e…    14600 breast                          1800      10.7  FALSE         cd16 mono             
+#>  6 22_1  842c6f5d-4a94-… b0d0c16e…    14600 breast                          1759      11.1  FALSE         cd16 mono             
+#>  7 21_1  842c6f5d-4a94-… b0d0c16e…    14600 breast                          1552      10.2  FALSE         cd16 mono             
+#>  8 11_1  842c6f5d-4a94-… bd5f6876…    14600 breast                           399      11.2  FALSE         cd16 mono             
+#>  9 25_2  842c6f5d-4a94-… 04e410cb…    14600 breast                          1324      13.0  FALSE         cd16 mono             
+#> 10 24_2  842c6f5d-4a94-… 04e410cb…    14600 breast                          1254      13.8  FALSE         cd16 mono             
+#> 11 13_2  842c6f5d-4a94-… 30ea4b4f…    14600 breast                          1368      11.0  FALSE         cd16 mono             
+#> 12 6_2   842c6f5d-4a94-… 49ef9551…    14600 breast                          1771      11.6  FALSE         cd16 mono             
+#> 13 9_2   842c6f5d-4a94-… 49ef9551…    14600 breast                          1767      12.3  FALSE         cd16 mono             
+#> # ℹ abbreviated names: ¹​nFeature_expressed_in_sample, ²​cell_type_unified_ensemble
+#> # ℹ 21 more variables: is_immune <lgl>, subsets_Mito_percent <int>, subsets_Ribo_percent <int>, high_mitochondrion <lgl>,
+#> #   high_ribosome <lgl>, alive <lgl>, scDblFinder.class <chr>, file_id_cellNexus_single_cell <chr>,
+#> #   file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>, inverse_transform <chr>,
+#> #   cell_annotation_blueprint_singler <chr>, cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>,
+#> #   ethnicity_flagging_score <dbl>, low_confidence_ethnicity <chr>, .aggregated_cells <int>, imputed_ethnicity <chr>,
+#> #   atlas_id <chr>, original_cell_ <chr>
 ```
 
 # Seurat
@@ -199,10 +223,36 @@ seurat_obj <- query_metadata |>
 #> ℹ Reading files.
 #> ℹ Compiling Experiment.
 seurat_obj
-#> An object of class Seurat 
-#> 33145 features across 13 samples within 1 assay 
-#> Active assay: originalexp (33145 features, 0 variable features)
-#>  2 layers present: counts, data
+#> Warning: `when()` was deprecated in purrr 1.0.0.
+#> ℹ Please use `if` instead.
+#> ℹ The deprecated feature was likely used in the tidyseurat package.
+#>   Please report the issue at <https://github.com/stemangiola/tidyseurat/issues>.
+#> This warning is displayed once per session.
+#> Call `lifecycle::last_lifecycle_warnings()` to see where this warning was generated.
+#> # A Seurat-tibble abstraction: 13 × 35
+#> # [90mFeatures=33145 | Cells=13 | Active assay=counts | Assays=counts[0m
+#>    .cell orig.ident nCount_originalexp nFeature_originalexp dataset_id   sample_id age_days tissue_groups nFeature_expressed_i…¹
+#>    <chr> <fct>                   <dbl>                <int> <chr>        <chr>        <int> <chr>                          <int>
+#>  1 19_1  19                       13.0                 1970 842c6f5d-4a… 1119f482…    14600 breast                          1876
+#>  2 14_1  14                       13.1                 1633 842c6f5d-4a… 1119f482…    14600 breast                          1547
+#>  3 16_1  16                       13.0                 2529 842c6f5d-4a… 1119f482…    14600 breast                          2438
+#>  4 2_1   2                        14.0                 1430 842c6f5d-4a… 1f755b9b…    14600 breast                          1342
+#>  5 24_1  24                       13.9                 1889 842c6f5d-4a… b0d0c16e…    14600 breast                          1800
+#>  6 22_1  22                       14.0                 1850 842c6f5d-4a… b0d0c16e…    14600 breast                          1759
+#>  7 21_1  21                       13.8                 1640 842c6f5d-4a… b0d0c16e…    14600 breast                          1552
+#>  8 11_1  11                       14.1                  456 842c6f5d-4a… bd5f6876…    14600 breast                           399
+#>  9 25_2  25                       18.9                 1416 842c6f5d-4a… 04e410cb…    14600 breast                          1324
+#> 10 24_2  24                       18.3                 1342 842c6f5d-4a… 04e410cb…    14600 breast                          1254
+#> 11 13_2  13                       14.0                 1456 842c6f5d-4a… 30ea4b4f…    14600 breast                          1368
+#> 12 6_2   6                        15.3                 1861 842c6f5d-4a… 49ef9551…    14600 breast                          1771
+#> 13 9_2   9                        15.6                 1857 842c6f5d-4a… 49ef9551…    14600 breast                          1767
+#> # ℹ abbreviated name: ¹​nFeature_expressed_in_sample
+#> # ℹ 26 more variables: nCount_RNA <dbl>, empty_droplet <lgl>, cell_type_unified_ensemble <chr>, is_immune <lgl>,
+#> #   subsets_Mito_percent <int>, subsets_Ribo_percent <int>, high_mitochondrion <lgl>, high_ribosome <lgl>, alive <lgl>,
+#> #   scDblFinder.class <chr>, file_id_cellNexus_single_cell <chr>, file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>,
+#> #   nfeature_expressed_thresh <dbl>, inverse_transform <chr>, cell_annotation_blueprint_singler <chr>,
+#> #   cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>,
+#> #   low_confidence_ethnicity <chr>, .aggregated_cells <int>, imputed_ethnicity <chr>, atlas_id <chr>, original_cell_ <chr>, …
 ```
 
 # Portable output examples
@@ -229,99 +279,121 @@ anndataR::write_h5ad(sce_counts, "single_cell_counts.h5ad")
 
 ``` r
 sessionInfo()
-#> R version 4.5.0 (2025-04-11)
-#> Platform: aarch64-apple-darwin20
-#> Running under: macOS Sonoma 14.8.7
+#> R version 4.5.3 (2026-03-11)
+#> Platform: x86_64-pc-linux-gnu
+#> Running under: Red Hat Enterprise Linux 9.6 (Plow)
 #> 
 #> Matrix products: default
-#> BLAS:   /Library/Frameworks/R.framework/Versions/4.5-arm64/Resources/lib/libRblas.0.dylib 
-#> LAPACK: /Library/Frameworks/R.framework/Versions/4.5-arm64/Resources/lib/libRlapack.dylib;  LAPACK version 3.12.1
+#> BLAS:   /stornext/System/data/software/rhel/9/base/tools/R/4.5.3/lib64/R/lib/libRblas.so 
+#> LAPACK: /stornext/System/data/software/rhel/9/base/tools/R/4.5.3/lib64/R/lib/libRlapack.so;  LAPACK version 3.12.1
 #> 
 #> locale:
-#> [1] en_US.UTF-8/en_US.UTF-8/en_US.UTF-8/C/en_US.UTF-8/en_US.UTF-8
+#>  [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C               LC_TIME=en_US.UTF-8        LC_COLLATE=en_US.UTF-8    
+#>  [5] LC_MONETARY=en_US.UTF-8    LC_MESSAGES=en_US.UTF-8    LC_PAPER=en_US.UTF-8       LC_NAME=C                 
+#>  [9] LC_ADDRESS=C               LC_TELEPHONE=C             LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C       
 #> 
 #> time zone: Australia/Melbourne
-#> tzcode source: internal
+#> tzcode source: system (glibc)
 #> 
 #> attached base packages:
-#> [1] stats     graphics  grDevices utils     datasets  methods   base     
+#> [1] stats4    stats     graphics  grDevices utils     datasets  methods   base     
 #> 
 #> other attached packages:
-#> [1] dplyr_1.2.1       cellNexus_0.99.23
+#>  [1] RcppSpdlog_0.0.28               cellNexus_0.99.30               purrr_1.2.2                    
+#>  [4] HPCell_0.6.0                    ggplot2_4.0.2                   tidyr_1.3.2                    
+#>  [7] tidySingleCellExperiment_1.20.1 ttservice_0.5.3                 SingleCellExperiment_1.32.0    
+#> [10] anndataR_1.3.1                  arrow_23.0.1.2                  SummarizedExperiment_1.40.0    
+#> [13] Biobase_2.70.0                  GenomicRanges_1.62.1            Seqinfo_1.0.0                  
+#> [16] IRanges_2.44.0                  S4Vectors_0.49.1-1              BiocGenerics_0.56.0            
+#> [19] generics_0.1.4                  MatrixGenerics_1.22.0           matrixStats_1.5.0              
+#> [22] dplyr_1.2.1                    
 #> 
 #> loaded via a namespace (and not attached):
-#>   [1] RColorBrewer_1.1-3          jsonlite_2.0.0             
-#>   [3] magrittr_2.0.5              spatstat.utils_3.2-2       
-#>   [5] farver_2.1.2                vctrs_0.7.3                
-#>   [7] ROCR_1.0-12                 spatstat.explore_3.8-0     
-#>   [9] htmltools_0.5.9             S4Arrays_1.10.1            
-#>  [11] curl_7.1.0                  Rhdf5lib_1.32.0            
-#>  [13] rhdf5_2.54.1                SparseArray_1.10.10        
-#>  [15] sass_0.4.10                 sctransform_0.4.3          
-#>  [17] parallelly_1.47.0           bslib_0.10.0               
-#>  [19] KernSmooth_2.23-26          basilisk_1.20.0            
-#>  [21] htmlwidgets_1.6.4           ica_1.0-3                  
-#>  [23] plyr_1.8.9                  cachem_1.1.0               
-#>  [25] plotly_4.12.0               zoo_1.8-15                 
-#>  [27] igraph_2.3.0                mime_0.13                  
-#>  [29] lifecycle_1.0.5             pkgconfig_2.0.3            
-#>  [31] Matrix_1.7-3                R6_2.6.1                   
-#>  [33] fastmap_1.2.0               anndataR_1.0.1             
-#>  [35] MatrixGenerics_1.22.0       fitdistrplus_1.2-6         
-#>  [37] future_1.70.0               shiny_1.13.0               
-#>  [39] digest_0.6.39               patchwork_1.3.2            
-#>  [41] S4Vectors_0.48.1            Seurat_5.5.0.9003          
-#>  [43] tensor_1.5.1                RSpectra_0.16-2            
-#>  [45] irlba_2.3.7                 GenomicRanges_1.62.1       
-#>  [47] filelock_1.0.3              progressr_0.19.0           
-#>  [49] spatstat.sparse_3.1-0       httr_1.4.8                 
-#>  [51] polyclip_1.10-7             abind_1.4-8                
-#>  [53] compiler_4.5.0              withr_3.0.2                
-#>  [55] backports_1.5.1             S7_0.2.2                   
-#>  [57] DBI_1.3.0                   fastDummies_1.7.6          
-#>  [59] HDF5Array_1.38.0            duckdb_1.2.2               
-#>  [61] MASS_7.3-65                 DelayedArray_0.36.1        
-#>  [63] tools_4.5.0                 lmtest_0.9-40              
-#>  [65] otel_0.2.0                  httpuv_1.6.17              
-#>  [67] future.apply_1.20.2         goftest_1.2-3              
-#>  [69] glue_1.8.1                  h5mread_1.2.1              
-#>  [71] rhdf5filters_1.22.0         nlme_3.1-168               
-#>  [73] promises_1.5.0              grid_4.5.0                 
-#>  [75] checkmate_2.3.2             Rtsne_0.17                 
-#>  [77] cluster_2.1.8.1             reshape2_1.4.5             
-#>  [79] generics_0.1.4              gtable_0.3.6               
-#>  [81] spatstat.data_3.1-9         tidyr_1.3.2                
-#>  [83] data.table_1.18.2.1         utf8_1.2.6                 
-#>  [85] sp_2.2-1                    XVector_0.50.0             
-#>  [87] BiocGenerics_0.56.0         spatstat.geom_3.7-3        
-#>  [89] RcppAnnoy_0.0.23            ggrepel_0.9.8              
-#>  [91] RANN_2.6.2                  pillar_1.11.1              
-#>  [93] stringr_1.6.0               spam_2.11-3                
-#>  [95] RcppHNSW_0.6.0              later_1.4.8                
-#>  [97] splines_4.5.0               lattice_0.22-6             
-#>  [99] survival_3.8-3              deldir_2.0-4               
-#> [101] tidyselect_1.2.1            SingleCellExperiment_1.32.0
-#> [103] miniUI_0.1.2                pbapply_1.7-4              
-#> [105] knitr_1.51                  gridExtra_2.3              
-#> [107] IRanges_2.44.0              Seqinfo_1.0.0              
-#> [109] SummarizedExperiment_1.40.0 scattermore_1.2            
-#> [111] stats4_4.5.0                xfun_0.57                  
-#> [113] Biobase_2.70.0              matrixStats_1.5.0          
-#> [115] stringi_1.8.7               lazyeval_0.2.3             
-#> [117] shinyWidgets_0.9.0          evaluate_1.0.5             
-#> [119] codetools_0.2-20            tibble_3.3.1               
-#> [121] cli_3.6.6                   uwot_0.2.4                 
-#> [123] xtable_1.8-8                reticulate_1.46.0          
-#> [125] jquerylib_0.1.4             zellkonverter_1.20.1       
-#> [127] Rcpp_1.1.1-1.1              dir.expiry_1.16.0          
-#> [129] globals_0.19.1              spatstat.random_3.4-5      
-#> [131] dbplyr_2.5.2                png_0.1-9                  
-#> [133] spatstat.univar_3.1-7       parallel_4.5.0             
-#> [135] blob_1.3.0                  rclipboard_0.2.1           
-#> [137] ggplot2_4.0.3               basilisk.utils_1.20.0      
-#> [139] dotCall64_1.2               listenv_0.10.1             
-#> [141] viridisLite_0.4.3           scales_1.4.0               
-#> [143] ggridges_0.5.7              SeuratObject_5.4.0         
-#> [145] purrr_1.2.2                 rlang_1.2.0                
-#> [147] cowplot_1.2.0
+#>   [1] igraph_2.2.3                    ica_1.0-3                       plotly_4.12.0                  
+#>   [4] SingleR_2.12.0                  scater_1.38.1                   devtools_2.5.0                 
+#>   [7] tidyselect_1.2.1                bit_4.6.0                       lattice_0.22-9                 
+#>  [10] rjson_0.2.21                    blob_1.3.0                      stringr_1.6.0                  
+#>  [13] S4Arrays_1.10.1                 rclipboard_0.2.1                parallel_4.5.3                 
+#>  [16] png_0.1-9                       cli_3.6.6                       ProtGenerics_1.42.0            
+#>  [19] askpass_1.2.1                   openssl_2.4.2                   goftest_1.2-3                  
+#>  [22] BiocIO_1.20.0                   bluster_1.20.0                  BiocNeighbors_2.4.0            
+#>  [25] tarchetypes_0.14.1              uwot_0.2.4                      curl_7.0.0                     
+#>  [28] mime_0.13                       evaluate_1.0.5                  stringi_1.8.7                  
+#>  [31] ids_1.0.1                       backports_1.5.1                 desc_1.4.3                     
+#>  [34] XML_3.99-0.23                   httpuv_1.6.17                   AnnotationDbi_1.72.0           
+#>  [37] magrittr_2.0.5                  rappdirs_0.3.4                  splines_4.5.3                  
+#>  [40] nanonext_1.8.2                  aws.signature_0.6.0             DT_0.34.0                      
+#>  [43] sctransform_0.4.3               ggbeeswarm_0.7.3                sessioninfo_1.2.3              
+#>  [46] DBI_1.3.0                       HDF5Array_1.38.0                jquerylib_0.1.4                
+#>  [49] withr_3.0.2                     reformulas_0.4.4                rprojroot_2.1.1                
+#>  [52] xgboost_3.2.1.1                 tidySummarizedExperiment_1.20.1 lmtest_0.9-40                  
+#>  [55] brio_1.1.5                      BiocManager_1.30.27             rtracklayer_1.70.1             
+#>  [58] duckdb_1.4.3                    htmlwidgets_1.6.4               fs_2.0.1                       
+#>  [61] biomaRt_2.66.2                  ggrepel_0.9.8                   SparseArray_1.10.10            
+#>  [64] tidyseurat_0.8.10               h5mread_1.2.1                   reticulate_1.46.0              
+#>  [67] zoo_1.8-15                      tiledbsoma_2.1.2                XVector_0.50.0                 
+#>  [70] knitr_1.51                      RcppCCTZ_0.2.14                 UCSC.utils_1.6.1               
+#>  [73] secretbase_1.2.1                fansi_1.0.7                     patchwork_1.3.2                
+#>  [76] pak_0.11.1                      grid_4.5.3                      data.table_1.18.2.1            
+#>  [79] rhdf5_2.54.1                    R.oo_1.27.1                     RSpectra_0.16-2                
+#>  [82] irlba_2.3.7                     tiledb_0.33.1                   commonmark_2.0.0               
+#>  [85] fastDummies_1.7.5               ellipsis_0.3.3                  base64url_1.4                  
+#>  [88] lazyeval_0.2.3                  yaml_2.3.12                     conflicted_1.2.0               
+#>  [91] survival_3.8-6                  scattermore_1.2                 crayon_1.5.3                   
+#>  [94] mirai_2.6.1                     RcppAnnoy_0.0.23                RColorBrewer_1.1-3             
+#>  [97] progressr_0.19.0                later_1.4.8                     ggridges_0.5.7                 
+#> [100] codetools_0.2-20                base64enc_0.1-6                 tidybulk_2.1.0                 
+#> [103] Seurat_5.5.0.9002               KEGGREST_1.50.0                 Rtsne_0.17                     
+#> [106] limma_3.66.0                    Rsamtools_2.26.0                filelock_1.0.3                 
+#> [109] pkgconfig_2.0.3                 xml2_1.5.2                      spatstat.univar_3.1-7          
+#> [112] GenomicAlignments_1.46.0        spatstat.sparse_3.1-0           viridisLite_0.4.3              
+#> [115] xtable_1.8-8                    plyr_1.8.9                      httr_1.4.8                     
+#> [118] rbibutils_2.4.1                 tools_4.5.3                     globals_0.19.1                 
+#> [121] SeuratObject_5.4.0              pkgbuild_1.4.8                  beeswarm_0.4.0                 
+#> [124] checkmate_2.3.4                 nlme_3.1-168                    dbplyr_2.5.2                   
+#> [127] assertthat_0.2.1                lme4_2.0-1                      digest_0.6.39                  
+#> [130] Matrix_1.7-4                    dir.expiry_1.18.0               farver_2.1.2                   
+#> [133] tzdb_0.5.0                      AnnotationFilter_1.34.0         reshape2_1.4.5                 
+#> [136] viridis_0.6.5                   glue_1.8.0                      cachem_1.1.0                   
+#> [139] BiocFileCache_3.0.0             polyclip_1.10-7                 rjsoncons_1.3.2                
+#> [142] Biostrings_2.78.0               parallelly_1.46.1               aws.s3_0.3.22                  
+#> [145] pkgload_1.5.1                   statmod_1.5.1                   here_1.0.2                     
+#> [148] RcppHNSW_0.6.0                  ScaledMatrix_1.18.0             minqa_1.2.8                    
+#> [151] pbapply_1.7-4                   httr2_1.2.2                     job_0.3.1                      
+#> [154] spam_2.11-3                     dqrng_0.4.1                     utf8_1.2.6                     
+#> [157] scDblFinder_1.24.10             basilisk_1.22.0                 crew_1.3.0                     
+#> [160] gridExtra_2.3                   shiny_1.13.0                    R.utils_2.13.0                 
+#> [163] rhdf5filters_1.22.0             RCurl_1.98-1.18                 memoise_2.0.1                  
+#> [166] rmarkdown_2.31                  nanoarrow_0.8.0                 scales_1.4.0                   
+#> [169] R.methodsS3_1.8.2               future_1.70.0                   RANN_2.6.2                     
+#> [172] renv_1.2.1                      spatstat.data_3.1-9             rstudioapi_0.18.0              
+#> [175] cluster_2.1.8.2                 zellkonverter_1.20.1            spatstat.utils_3.2-2           
+#> [178] hms_1.1.4                       fitdistrplus_1.2-6              cowplot_1.2.0                  
+#> [181] rlang_1.2.0                     GenomeInfoDb_1.46.2             crew.cluster_0.4.0             
+#> [184] DelayedMatrixStats_1.32.0       sparseMatrixStats_1.22.0        shinyWidgets_0.9.1             
+#> [187] dotCall64_1.2                   scuttle_1.20.0                  xfun_0.57                      
+#> [190] abind_1.4-8                     spdl_0.0.5                      tibble_3.3.1                   
+#> [193] EnsDb.Hsapiens.v86_2.99.0       Rhdf5lib_1.32.0                 readr_2.2.0                    
+#> [196] bitops_1.0-9                    Rdpack_2.6.6                    ps_1.9.2                       
+#> [199] promises_1.5.0                  RSQLite_2.4.6                   cellxgenedp_1.14.0             
+#> [202] DelayedArray_0.36.1             proxy_0.4-29                    compiler_4.5.3                 
+#> [205] prettyunits_1.2.0               boot_1.3-32                     beachmat_2.26.0                
+#> [208] listenv_0.10.1                  Rcpp_1.1.1-1                    edgeR_4.8.2                    
+#> [211] roxygen2_7.3.3                  BiocSingular_1.26.1             tensor_1.5.1                   
+#> [214] usethis_3.2.1                   MASS_7.3-65                     progress_1.2.3                 
+#> [217] uuid_1.2-2                      BiocParallel_1.44.0             ggupset_0.4.1                  
+#> [220] nanotime_0.3.13                 spatstat.random_3.4-5           R6_2.6.1                       
+#> [223] fastmap_1.2.0                   vipor_0.4.7                     ensembldb_2.34.0               
+#> [226] ROCR_1.0-12                     targets_1.12.0                  rsvd_1.0.5                     
+#> [229] gtable_0.3.6                    KernSmooth_2.23-26              miniUI_0.1.2                   
+#> [232] deldir_2.0-4                    htmltools_0.5.9                 bit64_4.6.0-1                  
+#> [235] spatstat.explore_3.8-0          lifecycle_1.0.5                 S7_0.2.1-1                     
+#> [238] processx_3.8.7                  nloptr_2.2.1                    callr_3.7.6                    
+#> [241] restfulr_0.0.16                 sass_0.4.10                     vctrs_0.7.3                    
+#> [244] testthat_3.3.2                  rsconnect_1.10.1                spatstat.geom_3.7-3            
+#> [247] scran_1.38.1                    sp_2.2-1                        future.apply_1.20.2            
+#> [250] bslib_0.10.0                    pillar_1.11.1                   GenomicFeatures_1.62.0         
+#> [253] DropletUtils_1.30.0             cellxgene.census_1.16.1         collections_0.3.12             
+#> [256] metapod_1.18.0                  locfit_1.5-9.12                 otel_0.2.0                     
+#> [259] BiocStyle_2.38.0                jsonlite_2.0.0                  cigarillo_1.0.0
 ```

--- a/vignettes/metadata-explore.Rmd
+++ b/vignettes/metadata-explore.Rmd
@@ -18,27 +18,27 @@ This page is a standalone metadata guide for `cellNexus` and documents the key f
 library(cellNexus)
 metadata <- get_metadata(cloud_metadata = SAMPLE_DATABASE_URL)
 metadata
-#> # Source:   SQL [?? x 36]
+#> # Source:   SQL [?? x 29]
 #> # Database: DuckDB 1.4.3 [unknown@Linux 5.14.0-570.123.1.el9_6.x86_64:R 4.5.3/:memory:]
-#>    cell_id dataset_id        sample_id sample_ experiment___ run_from_cell_id sample_heuristic age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA empty_droplet
-#>      <dbl> <chr>             <chr>     <chr>   <chr>         <chr>            <chr>               <int> <chr>                          <int>      <dbl> <lgl>        
-#>  1      15 842c6f5d-4a94-4e… 1119f482… 1119f4… ""            <NA>             182a61cc-b041-4…    14600 breast                          1701       8.99 FALSE        
-#>  2      16 842c6f5d-4a94-4e… 1119f482… 1119f4… ""            <NA>             182a61cc-b041-4…    14600 breast                          2438       9.80 FALSE        
-#>  3      17 842c6f5d-4a94-4e… 1119f482… 1119f4… ""            <NA>             182a61cc-b041-4…    14600 breast                          2122       9.46 FALSE        
-#>  4      18 842c6f5d-4a94-4e… 1119f482… 1119f4… ""            <NA>             182a61cc-b041-4…    14600 breast                          1894      10.3  FALSE        
-#>  5      19 842c6f5d-4a94-4e… 1119f482… 1119f4… ""            <NA>             182a61cc-b041-4…    14600 breast                          1876       9.15 FALSE        
-#>  6      20 842c6f5d-4a94-4e… 1119f482… 1119f4… ""            <NA>             182a61cc-b041-4…    14600 breast                          1441      10.3  FALSE        
-#>  7      14 842c6f5d-4a94-4e… 1119f482… 1119f4… ""            <NA>             182a61cc-b041-4…    14600 breast                          1547      10.5  FALSE        
-#>  8       2 842c6f5d-4a94-4e… 1f755b9b… 1f755b… ""            <NA>             9ca47fe5-873e-4…    14600 breast                          1342       9.40 FALSE        
-#>  9       3 842c6f5d-4a94-4e… 1f755b9b… 1f755b… ""            <NA>             9ca47fe5-873e-4…    14600 breast                          1808       9.80 FALSE        
-#> 10       4 842c6f5d-4a94-4e… 1f755b9b… 1f755b… ""            <NA>             9ca47fe5-873e-4…    14600 breast                          1514       9.30 FALSE        
+#>    cell_id dataset_id    sample_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA empty_droplet cell_type_unified_en…²
+#>      <dbl> <chr>         <chr>        <int> <chr>                          <int>      <dbl> <lgl>         <chr>                 
+#>  1      18 842c6f5d-4a9… 1119f482…    14600 breast                          1894      10.3  FALSE         cd14 mono             
+#>  2      19 842c6f5d-4a9… 1119f482…    14600 breast                          1876       9.15 FALSE         cd16 mono             
+#>  3      20 842c6f5d-4a9… 1119f482…    14600 breast                          1441      10.3  FALSE         cd14 mono             
+#>  4      14 842c6f5d-4a9… 1119f482…    14600 breast                          1547      10.5  FALSE         cd16 mono             
+#>  5      15 842c6f5d-4a9… 1119f482…    14600 breast                          1701       8.99 FALSE         cd14 mono             
+#>  6      16 842c6f5d-4a9… 1119f482…    14600 breast                          2438       9.80 FALSE         cd16 mono             
+#>  7      17 842c6f5d-4a9… 1119f482…    14600 breast                          2122       9.46 FALSE         cd14 mono             
+#>  8       2 842c6f5d-4a9… 1f755b9b…    14600 breast                          1342       9.40 FALSE         cd16 mono             
+#>  9       5 842c6f5d-4a9… 1f755b9b…    14600 breast                          1820       9.25 FALSE         cd14 mono             
+#> 10       4 842c6f5d-4a9… 1f755b9b…    14600 breast                          1514       9.30 FALSE         cd14 mono             
 #> # ℹ more rows
-#> # ℹ abbreviated name: ¹​nFeature_expressed_in_sample
-#> # ℹ 24 more variables: cell_type_unified_ensemble <chr>, is_immune <lgl>, subsets_Mito_percent <int>, subsets_Ribo_percent <int>, high_mitochondrion <lgl>,
-#> #   high_ribosome <lgl>, scDblFinder.class <chr>, sample_chunk <int>, cell_chunk <int>, sample_pseudobulk_chunk <int>, file_id_cellNexus_single_cell <chr>,
-#> #   file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>, inverse_transform <chr>, alive <lgl>,
-#> #   cell_annotation_blueprint_singler <chr>, cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>, ethnicity_flagging_score <dbl>,
-#> #   low_confidence_ethnicity <chr>, .aggregated_cells <int>, imputed_ethnicity <chr>, atlas_id <chr>
+#> # ℹ abbreviated names: ¹​nFeature_expressed_in_sample, ²​cell_type_unified_ensemble
+#> # ℹ 20 more variables: is_immune <lgl>, subsets_Mito_percent <int>, subsets_Ribo_percent <int>, high_mitochondrion <lgl>,
+#> #   high_ribosome <lgl>, alive <lgl>, scDblFinder.class <chr>, file_id_cellNexus_single_cell <chr>,
+#> #   file_id_cellNexus_pseudobulk <chr>, count_upper_bound <dbl>, nfeature_expressed_thresh <dbl>, inverse_transform <chr>,
+#> #   cell_annotation_blueprint_singler <chr>, cell_annotation_monaco_singler <chr>, cell_annotation_azimuth_l2 <chr>,
+#> #   ethnicity_flagging_score <dbl>, low_confidence_ethnicity <chr>, .aggregated_cells <int>, imputed_ethnicity <chr>, …
 ```
 
 # Data-processing context
@@ -57,9 +57,7 @@ metadata
   | `observation_joinid` | Cell ID join key linking metadata. |
   | `dataset_id` | Primary dataset identifier in the atlas. |
   | `sample_id` | Harmonised sample identifier. |
-  | `sample_` | Internal sample subdivision helper. |
-  | `experiment___` | Upstream experiment grouping variable. |
-  | `sample_heuristic` | Internal sample subdivision helper. |
+  | `donor_id` | Donor identifier. |
   | `age_days` | Donor age in days. |
   | `tissue_groups` | Coarse tissue grouping for analysis. |
   | `nFeature_expressed_in_sample` | Number of expressed features per cell. |
@@ -72,9 +70,6 @@ metadata
   | `high_mitochondrion` | TRUE if the cell’s mitochondrial percent exceeds the QC cutoff. |
   | `high_ribosome` | TRUE if the cell’s ribosomal percent exceeds the QC cutoff. |
   | `scDblFinder.class` | Quality-control flag for doublet classification from `scDblFinder`. |
-  | `sample_chunk ` | Internal sample subdivision chunks. |
-  | `cell_chunk ` | Internal cell subdivision chunks. |
-  | `sample_pseudobulk_chunk ` | Internal pseudobulk subdivision chunks. |
   | `file_id_cellNexus_single_cell` | Internal file id for single-cell layers. |
   | `file_id_cellNexus_pseudobulk` | Internal file id for pseudobulk layers. |
   | `count_upper_bound` | Count capping threshold used in transformation. |
@@ -97,15 +92,16 @@ metadata
 ``` r
 # Which columns are available?
 colnames(metadata)
-#>  [1] "cell_id"                           "dataset_id"                        "sample_id"                         "sample_"                          
-#>  [5] "experiment___"                     "run_from_cell_id"                  "sample_heuristic"                  "age_days"                         
-#>  [9] "tissue_groups"                     "nFeature_expressed_in_sample"      "nCount_RNA"                        "empty_droplet"                    
-#> [13] "cell_type_unified_ensemble"        "is_immune"                         "subsets_Mito_percent"              "subsets_Ribo_percent"             
-#> [17] "high_mitochondrion"                "high_ribosome"                     "scDblFinder.class"                 "sample_chunk"                     
-#> [21] "cell_chunk"                        "sample_pseudobulk_chunk"           "file_id_cellNexus_single_cell"     "file_id_cellNexus_pseudobulk"     
-#> [25] "count_upper_bound"                 "nfeature_expressed_thresh"         "inverse_transform"                 "alive"                            
-#> [29] "cell_annotation_blueprint_singler" "cell_annotation_monaco_singler"    "cell_annotation_azimuth_l2"        "ethnicity_flagging_score"         
-#> [33] "low_confidence_ethnicity"          ".aggregated_cells"                 "imputed_ethnicity"                 "atlas_id"
+#>  [1] "cell_id"                           "dataset_id"                        "sample_id"                        
+#>  [4] "age_days"                          "tissue_groups"                     "nFeature_expressed_in_sample"     
+#>  [7] "nCount_RNA"                        "empty_droplet"                     "cell_type_unified_ensemble"       
+#> [10] "is_immune"                         "subsets_Mito_percent"              "subsets_Ribo_percent"             
+#> [13] "high_mitochondrion"                "high_ribosome"                     "alive"                            
+#> [16] "scDblFinder.class"                 "file_id_cellNexus_single_cell"     "file_id_cellNexus_pseudobulk"     
+#> [19] "count_upper_bound"                 "nfeature_expressed_thresh"         "inverse_transform"                
+#> [22] "cell_annotation_blueprint_singler" "cell_annotation_monaco_singler"    "cell_annotation_azimuth_l2"       
+#> [25] "ethnicity_flagging_score"          "low_confidence_ethnicity"          ".aggregated_cells"                
+#> [28] "imputed_ethnicity"                 "atlas_id"
 
 # How many datasets per tissue group?
 metadata |>
@@ -120,21 +116,21 @@ metadata |>
 #>  2 respiratory system                      7
 #>  3 bone marrow                             6
 #>  4 renal system                            4
-#>  5 thymus                                  3
-#>  6 breast                                  3
+#>  5 breast                                  3
+#>  6 thymus                                  3
 #>  7 cerebral lobes and cortical areas       2
-#>  8 female reproductive system              2
-#>  9 spleen                                  2
+#>  8 spleen                                  2
+#>  9 female reproductive system              2
 #> 10 nasal, oral, and pharyngeal regions     2
-#> 11 oesophagus                              1
-#> 12 lymphatic system                        1
-#> 13 epithelium and mucosal tissues          1
-#> 14 stomach                                 1
-#> 15 vasculature                             1
-#> 16 small intestine                         1
-#> 17 endocrine system                        1
-#> 18 brainstem and cerebellar structures     1
-#> 19 sensory-related structures              1
+#> 11 sensory-related structures              1
+#> 12 brainstem and cerebellar structures     1
+#> 13 oesophagus                              1
+#> 14 lymphatic system                        1
+#> 15 epithelium and mucosal tissues          1
+#> 16 stomach                                 1
+#> 17 vasculature                             1
+#> 18 small intestine                         1
+#> 19 endocrine system                        1
 
 # Typical quality-control filtering
 metadata_qc <- metadata |>
@@ -157,9 +153,9 @@ sessionInfo()
 #> LAPACK: /stornext/System/data/software/rhel/9/base/tools/R/4.5.3/lib64/R/lib/libRlapack.so;  LAPACK version 3.12.1
 #> 
 #> locale:
-#>  [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C               LC_TIME=en_US.UTF-8        LC_COLLATE=en_US.UTF-8     LC_MONETARY=en_US.UTF-8   
-#>  [6] LC_MESSAGES=en_US.UTF-8    LC_PAPER=en_US.UTF-8       LC_NAME=C                  LC_ADDRESS=C               LC_TELEPHONE=C            
-#> [11] LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C       
+#>  [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C               LC_TIME=en_US.UTF-8        LC_COLLATE=en_US.UTF-8    
+#>  [5] LC_MONETARY=en_US.UTF-8    LC_MESSAGES=en_US.UTF-8    LC_PAPER=en_US.UTF-8       LC_NAME=C                 
+#>  [9] LC_ADDRESS=C               LC_TELEPHONE=C             LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C       
 #> 
 #> time zone: Australia/Melbourne
 #> tzcode source: system (glibc)
@@ -168,47 +164,101 @@ sessionInfo()
 #> [1] stats4    stats     graphics  grDevices utils     datasets  methods   base     
 #> 
 #> other attached packages:
-#>  [1] BiocStyle_2.38.0            RcppSpdlog_0.0.28           ggplot2_4.0.2               SummarizedExperiment_1.40.0 Biobase_2.70.0             
-#>  [6] GenomicRanges_1.62.1        Seqinfo_1.0.0               IRanges_2.44.0              S4Vectors_0.49.1-1          BiocGenerics_0.56.0        
-#> [11] generics_0.1.4              MatrixGenerics_1.22.0       matrixStats_1.5.0           shiny_1.13.0                anndataR_1.0.2             
-#> [16] cellNexus_0.99.27           testthat_3.3.2              dplyr_1.2.1                
+#>  [1] RcppSpdlog_0.0.28               cellNexus_0.99.30               purrr_1.2.2                    
+#>  [4] HPCell_0.6.0                    ggplot2_4.0.2                   tidyr_1.3.2                    
+#>  [7] tidySingleCellExperiment_1.20.1 ttservice_0.5.3                 SingleCellExperiment_1.32.0    
+#> [10] anndataR_1.3.1                  arrow_23.0.1.2                  SummarizedExperiment_1.40.0    
+#> [13] Biobase_2.70.0                  GenomicRanges_1.62.1            Seqinfo_1.0.0                  
+#> [16] IRanges_2.44.0                  S4Vectors_0.49.1-1              BiocGenerics_0.56.0            
+#> [19] generics_0.1.4                  MatrixGenerics_1.22.0           matrixStats_1.5.0              
+#> [22] dplyr_1.2.1                    
 #> 
 #> loaded via a namespace (and not attached):
-#>   [1] fs_2.0.1                        spatstat.sparse_3.1-0           fontawesome_0.5.3               devtools_2.5.0                  httr_1.4.8                     
-#>   [6] RColorBrewer_1.1-3              tools_4.5.3                     sctransform_0.4.3               backports_1.5.1                 utf8_1.2.6                     
-#>  [11] R6_2.6.1                        DT_0.34.0                       HDF5Array_1.38.0                lazyeval_0.2.3                  uwot_0.2.4                     
-#>  [16] rhdf5filters_1.22.0             withr_3.0.2                     sp_2.2-1                        gridExtra_2.3                   nanoarrow_0.8.0                
-#>  [21] progressr_0.19.0                cli_3.6.6                       spatstat.explore_3.8-0          fastDummies_1.7.5               sass_0.4.10                    
-#>  [26] Seurat_5.5.0.9002               arrow_23.0.1.2                  S7_0.2.1-1                      spatstat.data_3.1-9             ggridges_0.5.7                 
-#>  [31] pbapply_1.7-4                   commonmark_2.0.0                R.utils_2.13.0                  parallelly_1.46.1               sessioninfo_1.2.3              
-#>  [36] rstudioapi_0.18.0               ica_1.0-3                       spatstat.random_3.4-5           Matrix_1.7-4                    fansi_1.0.7                    
-#>  [41] waldo_0.6.2                     rclipboard_0.2.1                abind_1.4-8                     R.methodsS3_1.8.2               lifecycle_1.0.5                
-#>  [46] yaml_2.3.12                     rhdf5_2.54.1                    SparseArray_1.10.10             Rtsne_0.17                      grid_4.5.3                     
-#>  [51] blob_1.3.0                      promises_1.5.0                  dir.expiry_1.18.0               miniUI_0.1.2                    lattice_0.22-9                 
-#>  [56] cowplot_1.2.0                   pillar_1.11.1                   knitr_1.51                      future.apply_1.20.2             codetools_0.2-20               
-#>  [61] glue_1.8.0                      tiledb_0.33.1                   spatstat.univar_3.1-7           data.table_1.18.2.1             tidySingleCellExperiment_1.20.1
-#>  [66] vctrs_0.7.3                     png_0.1-9                       spam_2.11-3                     gtable_0.3.6                    aws.s3_0.3.22                  
-#>  [71] assertthat_0.2.1                cachem_1.1.0                    xfun_0.57                       S4Arrays_1.10.1                 mime_0.13                      
-#>  [76] rsconnect_1.8.0                 survival_3.8-6                  SingleCellExperiment_1.32.0     ellipsis_0.3.3                  fitdistrplus_1.2-6             
-#>  [81] ROCR_1.0-12                     tiledbsoma_2.1.2                nlme_3.1-168                    RcppCCTZ_0.2.14                 usethis_3.2.1                  
-#>  [86] bit64_4.6.0-1                   filelock_1.0.3                  RcppAnnoy_0.0.23                GenomeInfoDb_1.46.2             rprojroot_2.1.1                
-#>  [91] R.cache_0.17.0                  bslib_0.10.0                    irlba_2.3.7                     KernSmooth_2.23-26              otel_0.2.0                     
-#>  [96] DBI_1.3.0                       zellkonverter_1.20.1            duckdb_1.4.3                    tidyselect_1.2.1                cellxgene.census_1.16.1        
-#> [101] bit_4.6.0                       compiler_4.5.3                  curl_7.0.0                      rjsoncons_1.3.2                 h5mread_1.2.1                  
-#> [106] xml2_1.5.2                      nanotime_0.3.13                 desc_1.4.3                      DelayedArray_0.36.1             plotly_4.12.0                  
-#> [111] bookdown_0.46                   checkmate_2.3.4                 scales_1.4.0                    lmtest_0.9-40                   spdl_0.0.5                     
-#> [116] stringr_1.6.0                   digest_0.6.39                   goftest_1.2-3                   spatstat.utils_3.2-2            rmarkdown_2.31                 
-#> [121] basilisk_1.22.0                 XVector_0.50.0                  htmltools_0.5.9                 pkgconfig_2.0.3                 base64enc_0.1-6                
-#> [126] dbplyr_2.5.2                    fastmap_1.2.0                   rlang_1.2.0                     htmlwidgets_1.6.4               UCSC.utils_1.6.1               
-#> [131] farver_2.1.2                    jquerylib_0.1.4                 zoo_1.8-15                      jsonlite_2.0.0                  R.oo_1.27.1                    
-#> [136] magrittr_2.0.5                  dotCall64_1.2                   patchwork_1.3.2                 Rhdf5lib_1.32.0                 Rcpp_1.1.1-1                   
-#> [141] reticulate_1.46.0               stringi_1.8.7                   brio_1.1.5                      MASS_7.3-65                     plyr_1.8.9                     
-#> [146] pkgbuild_1.4.8                  parallel_4.5.3                  listenv_0.10.1                  ggrepel_0.9.8                   forcats_1.0.1                  
-#> [151] deldir_2.0-4                    splines_4.5.3                   tensor_1.5.1                    igraph_2.2.3                    cellxgenedp_1.14.0             
-#> [156] spatstat.geom_3.7-3             RcppHNSW_0.6.0                  reshape2_1.4.5                  pkgload_1.5.1                   ttservice_0.5.3                
-#> [161] evaluate_1.0.5                  SeuratObject_5.4.0              BiocManager_1.30.27             httpuv_1.6.17                   RANN_2.6.2                     
-#> [166] tidyr_1.3.2                     purrr_1.2.2                     polyclip_1.10-7                 future_1.70.0                   scattermore_1.2                
-#> [171] xtable_1.8-8                    RSpectra_0.16-2                 roxygen2_7.3.3                  later_1.4.8                     viridisLite_0.4.3              
-#> [176] tibble_3.3.1                    memoise_2.0.1                   aws.signature_0.6.0             cluster_2.1.8.2                 shinyWidgets_0.9.1             
-#> [181] globals_0.19.1
+#>   [1] igraph_2.2.3                    ica_1.0-3                       plotly_4.12.0                  
+#>   [4] SingleR_2.12.0                  scater_1.38.1                   devtools_2.5.0                 
+#>   [7] tidyselect_1.2.1                bit_4.6.0                       lattice_0.22-9                 
+#>  [10] rjson_0.2.21                    blob_1.3.0                      stringr_1.6.0                  
+#>  [13] S4Arrays_1.10.1                 rclipboard_0.2.1                parallel_4.5.3                 
+#>  [16] png_0.1-9                       cli_3.6.6                       ProtGenerics_1.42.0            
+#>  [19] askpass_1.2.1                   openssl_2.4.2                   goftest_1.2-3                  
+#>  [22] BiocIO_1.20.0                   bluster_1.20.0                  BiocNeighbors_2.4.0            
+#>  [25] tarchetypes_0.14.1              uwot_0.2.4                      curl_7.0.0                     
+#>  [28] mime_0.13                       evaluate_1.0.5                  stringi_1.8.7                  
+#>  [31] ids_1.0.1                       backports_1.5.1                 desc_1.4.3                     
+#>  [34] XML_3.99-0.23                   httpuv_1.6.17                   AnnotationDbi_1.72.0           
+#>  [37] magrittr_2.0.5                  rappdirs_0.3.4                  splines_4.5.3                  
+#>  [40] nanonext_1.8.2                  aws.signature_0.6.0             DT_0.34.0                      
+#>  [43] sctransform_0.4.3               ggbeeswarm_0.7.3                sessioninfo_1.2.3              
+#>  [46] DBI_1.3.0                       HDF5Array_1.38.0                jquerylib_0.1.4                
+#>  [49] withr_3.0.2                     reformulas_0.4.4                rprojroot_2.1.1                
+#>  [52] xgboost_3.2.1.1                 tidySummarizedExperiment_1.20.1 lmtest_0.9-40                  
+#>  [55] brio_1.1.5                      BiocManager_1.30.27             rtracklayer_1.70.1             
+#>  [58] duckdb_1.4.3                    htmlwidgets_1.6.4               fs_2.0.1                       
+#>  [61] biomaRt_2.66.2                  ggrepel_0.9.8                   SparseArray_1.10.10            
+#>  [64] tidyseurat_0.8.10               h5mread_1.2.1                   reticulate_1.46.0              
+#>  [67] zoo_1.8-15                      tiledbsoma_2.1.2                XVector_0.50.0                 
+#>  [70] knitr_1.51                      RcppCCTZ_0.2.14                 UCSC.utils_1.6.1               
+#>  [73] secretbase_1.2.1                fansi_1.0.7                     patchwork_1.3.2                
+#>  [76] pak_0.11.1                      grid_4.5.3                      data.table_1.18.2.1            
+#>  [79] rhdf5_2.54.1                    R.oo_1.27.1                     RSpectra_0.16-2                
+#>  [82] irlba_2.3.7                     tiledb_0.33.1                   commonmark_2.0.0               
+#>  [85] fastDummies_1.7.5               ellipsis_0.3.3                  base64url_1.4                  
+#>  [88] lazyeval_0.2.3                  yaml_2.3.12                     conflicted_1.2.0               
+#>  [91] survival_3.8-6                  scattermore_1.2                 crayon_1.5.3                   
+#>  [94] mirai_2.6.1                     RcppAnnoy_0.0.23                RColorBrewer_1.1-3             
+#>  [97] progressr_0.19.0                later_1.4.8                     ggridges_0.5.7                 
+#> [100] codetools_0.2-20                base64enc_0.1-6                 tidybulk_2.1.0                 
+#> [103] Seurat_5.5.0.9002               KEGGREST_1.50.0                 Rtsne_0.17                     
+#> [106] limma_3.66.0                    Rsamtools_2.26.0                filelock_1.0.3                 
+#> [109] pkgconfig_2.0.3                 xml2_1.5.2                      spatstat.univar_3.1-7          
+#> [112] GenomicAlignments_1.46.0        spatstat.sparse_3.1-0           viridisLite_0.4.3              
+#> [115] xtable_1.8-8                    plyr_1.8.9                      httr_1.4.8                     
+#> [118] rbibutils_2.4.1                 tools_4.5.3                     globals_0.19.1                 
+#> [121] SeuratObject_5.4.0              pkgbuild_1.4.8                  beeswarm_0.4.0                 
+#> [124] checkmate_2.3.4                 nlme_3.1-168                    dbplyr_2.5.2                   
+#> [127] assertthat_0.2.1                lme4_2.0-1                      digest_0.6.39                  
+#> [130] Matrix_1.7-4                    dir.expiry_1.18.0               farver_2.1.2                   
+#> [133] tzdb_0.5.0                      AnnotationFilter_1.34.0         reshape2_1.4.5                 
+#> [136] viridis_0.6.5                   glue_1.8.0                      cachem_1.1.0                   
+#> [139] BiocFileCache_3.0.0             polyclip_1.10-7                 rjsoncons_1.3.2                
+#> [142] Biostrings_2.78.0               parallelly_1.46.1               aws.s3_0.3.22                  
+#> [145] pkgload_1.5.1                   statmod_1.5.1                   here_1.0.2                     
+#> [148] RcppHNSW_0.6.0                  ScaledMatrix_1.18.0             minqa_1.2.8                    
+#> [151] pbapply_1.7-4                   httr2_1.2.2                     job_0.3.1                      
+#> [154] spam_2.11-3                     dqrng_0.4.1                     utf8_1.2.6                     
+#> [157] scDblFinder_1.24.10             basilisk_1.22.0                 crew_1.3.0                     
+#> [160] gridExtra_2.3                   shiny_1.13.0                    R.utils_2.13.0                 
+#> [163] rhdf5filters_1.22.0             RCurl_1.98-1.18                 memoise_2.0.1                  
+#> [166] rmarkdown_2.31                  nanoarrow_0.8.0                 scales_1.4.0                   
+#> [169] R.methodsS3_1.8.2               future_1.70.0                   RANN_2.6.2                     
+#> [172] renv_1.2.1                      spatstat.data_3.1-9             rstudioapi_0.18.0              
+#> [175] cluster_2.1.8.2                 zellkonverter_1.20.1            spatstat.utils_3.2-2           
+#> [178] hms_1.1.4                       fitdistrplus_1.2-6              cowplot_1.2.0                  
+#> [181] rlang_1.2.0                     GenomeInfoDb_1.46.2             crew.cluster_0.4.0             
+#> [184] DelayedMatrixStats_1.32.0       sparseMatrixStats_1.22.0        shinyWidgets_0.9.1             
+#> [187] dotCall64_1.2                   scuttle_1.20.0                  xfun_0.57                      
+#> [190] abind_1.4-8                     spdl_0.0.5                      tibble_3.3.1                   
+#> [193] EnsDb.Hsapiens.v86_2.99.0       Rhdf5lib_1.32.0                 readr_2.2.0                    
+#> [196] bitops_1.0-9                    Rdpack_2.6.6                    ps_1.9.2                       
+#> [199] promises_1.5.0                  RSQLite_2.4.6                   cellxgenedp_1.14.0             
+#> [202] DelayedArray_0.36.1             proxy_0.4-29                    compiler_4.5.3                 
+#> [205] prettyunits_1.2.0               boot_1.3-32                     beachmat_2.26.0                
+#> [208] listenv_0.10.1                  Rcpp_1.1.1-1                    edgeR_4.8.2                    
+#> [211] roxygen2_7.3.3                  BiocSingular_1.26.1             tensor_1.5.1                   
+#> [214] usethis_3.2.1                   MASS_7.3-65                     progress_1.2.3                 
+#> [217] uuid_1.2-2                      BiocParallel_1.44.0             ggupset_0.4.1                  
+#> [220] nanotime_0.3.13                 spatstat.random_3.4-5           R6_2.6.1                       
+#> [223] fastmap_1.2.0                   vipor_0.4.7                     ensembldb_2.34.0               
+#> [226] ROCR_1.0-12                     targets_1.12.0                  rsvd_1.0.5                     
+#> [229] gtable_0.3.6                    KernSmooth_2.23-26              miniUI_0.1.2                   
+#> [232] deldir_2.0-4                    htmltools_0.5.9                 bit64_4.6.0-1                  
+#> [235] spatstat.explore_3.8-0          lifecycle_1.0.5                 S7_0.2.1-1                     
+#> [238] processx_3.8.7                  nloptr_2.2.1                    callr_3.7.6                    
+#> [241] restfulr_0.0.16                 sass_0.4.10                     vctrs_0.7.3                    
+#> [244] testthat_3.3.2                  rsconnect_1.10.1                spatstat.geom_3.7-3            
+#> [247] scran_1.38.1                    sp_2.2-1                        future.apply_1.20.2            
+#> [250] bslib_0.10.0                    pillar_1.11.1                   GenomicFeatures_1.62.0         
+#> [253] DropletUtils_1.30.0             cellxgene.census_1.16.1         collections_0.3.12             
+#> [256] metapod_1.18.0                  locfit_1.5-9.12                 otel_0.2.0                     
+#> [259] BiocStyle_2.38.0                jsonlite_2.0.0                  cigarillo_1.0.0
 ```

--- a/vignettes/metadata-explore.Rmd.orig
+++ b/vignettes/metadata-explore.Rmd.orig
@@ -37,9 +37,7 @@ metadata
   | `observation_joinid` | Cell ID join key linking metadata. |
   | `dataset_id` | Primary dataset identifier in the atlas. |
   | `sample_id` | Harmonised sample identifier. |
-  | `sample_` | Internal sample subdivision helper. |
-  | `experiment___` | Upstream experiment grouping variable. |
-  | `sample_heuristic` | Internal sample subdivision helper. |
+  | `donor_id` | Donor identifier. |
   | `age_days` | Donor age in days. |
   | `tissue_groups` | Coarse tissue grouping for analysis. |
   | `nFeature_expressed_in_sample` | Number of expressed features per cell. |
@@ -52,9 +50,6 @@ metadata
   | `high_mitochondrion` | TRUE if the cell’s mitochondrial percent exceeds the QC cutoff. |
   | `high_ribosome` | TRUE if the cell’s ribosomal percent exceeds the QC cutoff. |
   | `scDblFinder.class` | Quality-control flag for doublet classification from `scDblFinder`. |
-  | `sample_chunk ` | Internal sample subdivision chunks. |
-  | `cell_chunk ` | Internal cell subdivision chunks. |
-  | `sample_pseudobulk_chunk ` | Internal pseudobulk subdivision chunks. |
   | `file_id_cellNexus_single_cell` | Internal file id for single-cell layers. |
   | `file_id_cellNexus_pseudobulk` | Internal file id for pseudobulk layers. |
   | `count_upper_bound` | Count capping threshold used in transformation. |


### PR DESCRIPTION
In summary, this PR addressed #145 by adding donor_id to harmonised metadata and dropping internal columns from documentations. 
