### PR TITLE
add download_only argument to get_* functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: cellNexus
 Title: Queries the Human Cell Atlas
-Version: 0.99.31
+Version: 0.99.32
 Authors@R: c(
     person(
         "Stefano",

--- a/R/counts.R
+++ b/R/counts.R
@@ -65,8 +65,13 @@ get_SingleCellExperiment <- function(...) {
 #'   an HTTP URL pointing to the location where the single cell data is stored.
 #' @param features An optional character vector of features (ie genes) to return
 #'   the counts for. By default counts for all features will be returned.
+#' @param download_only Logical scalar. When `TRUE`, remote files are
+#'   synchronised to `cache_directory` but the data is not read or assembled
+#'   into an in-memory object. Returns `invisible(NULL)`. Useful for
+#'   pre-fetching datasets only.
 #' @importFrom dplyr pull filter as_tibble inner_join collect transmute group_split
-#' @return A `SingleCellExperiment` object.
+#' @return A `SingleCellExperiment` object, or `invisible(NULL)` when
+#'   `download_only = TRUE`.
 #' @importFrom tibble column_to_rownames
 #' @importFrom BiocGenerics cbind
 #' @importFrom glue glue
@@ -92,7 +97,8 @@ get_single_cell_experiment <- function(data,
                                        cell_aggregation = "",
                                        cache_directory = get_default_cache_dir(),
                                        repository = COUNTS_URL,
-                                       features = NULL) {
+                                       features = NULL,
+                                       download_only = FALSE) {
   raw_data <- collect(data)
   assert(
     check_true(inherits(raw_data, "tbl")),
@@ -127,7 +133,8 @@ get_single_cell_experiment <- function(data,
     cache_directory = cache_directory,
     repository = repository,
     grouping_column = "file_id_cellNexus_single_cell",
-    features = features
+    features = features,
+    download_only = download_only
   )
 }
 
@@ -163,6 +170,11 @@ get_single_cell_experiment <- function(data,
 #' @param as_SummarizedExperiment If `TRUE`, coerce the result to a
 #'   `SummarizedExperiment`. Note that `as(x, "SummarizedExperiment")` drops
 #'   feature rownames; `get_pseudobulk()` restores them after coercion.
+#'   Ignored when `download_only = TRUE`.
+#' @param download_only Logical scalar. When `TRUE`, remote files are
+#'   synchronised to `cache_directory` but the data is not read or assembled
+#'   into an in-memory object. Returns `invisible(NULL)`. Useful for
+#'   pre-fetching datasets only.
 #' @details
 #' Columns in `data` that are constant within each
 #' `sample_id` x `cell_type_unified_ensemble` combination (including
@@ -170,6 +182,7 @@ get_single_cell_experiment <- function(data,
 #' dropped via internal `keep_specific_annotation_columns()`.
 #' @return By default, a `SingleCellExperiment` object. If
 #'   `as_SummarizedExperiment` is `TRUE`, a `SummarizedExperiment` object.
+#'   Returns `invisible(NULL)` when `download_only = TRUE`.
 #' @importFrom dplyr pull filter as_tibble inner_join collect transmute
 #' @importFrom tibble column_to_rownames
 #' @importFrom BiocGenerics cbind
@@ -199,7 +212,8 @@ get_pseudobulk <- function(data,
                            cache_directory = get_default_cache_dir(),
                            repository = COUNTS_URL,
                            features = NULL,
-                           as_SummarizedExperiment = FALSE) {
+                           as_SummarizedExperiment = FALSE,
+                           download_only = FALSE) {
   raw_data <- collect(data)
   assert(
     check_true(inherits(raw_data, "tbl")),
@@ -230,14 +244,19 @@ get_pseudobulk <- function(data,
 
   validate_data(raw_data, assays, cell_aggregation, cache_directory, repository, features)
 
-  # Compute once on the full query so every file-level SCE shares identical
-  # colData columns before cbind(); per-file FD detection can disagree.
-  pseudobulk_coldata_columns <- get_specific_annotation_columns(
-    raw_data,
-    c(sample_id, cell_type_unified_ensemble),
-    sample_n = 100000L,
-    include_query_columns = TRUE
-  )
+  # colData column detection is only needed for reading, not for download-only.
+  pseudobulk_coldata_columns <- if (!download_only) {
+    # Compute once on the full query so every file-level SCE shares identical
+    # colData columns before cbind(); per-file FD detection can disagree.
+    get_specific_annotation_columns(
+      raw_data,
+      c(sample_id, cell_type_unified_ensemble),
+      sample_n = 100000L,
+      include_query_columns = TRUE
+    )
+  } else {
+    NULL
+  }
 
   res <- .fetch_experiments(
     raw_data = raw_data,
@@ -247,8 +266,13 @@ get_pseudobulk <- function(data,
     repository = repository,
     grouping_column = "file_id_cellNexus_pseudobulk",
     features = features,
-    coldata_columns = pseudobulk_coldata_columns
+    coldata_columns = pseudobulk_coldata_columns,
+    download_only = download_only
   )
+
+  if (download_only) {
+    return(invisible(NULL))
+  }
 
   if (as_SummarizedExperiment) {
     rn <- rownames(res)
@@ -438,7 +462,11 @@ get_metacell <- function(data,
 #' @param coldata_columns Optional character vector of colData columns to keep
 #'   for pseudobulk or metacell (computed once on the full query). Ignored for
 #'   single-cell aggregation.
-#' @return A \code{SingleCellExperiment} or \code{SummarizedExperiment} object.
+#' @param download_only Logical scalar. When \code{TRUE}, the function performs
+#'   only the remote-to-cache synchronisation step and returns
+#'   \code{invisible(NULL)} without reading or assembling any objects.
+#' @return A \code{SingleCellExperiment} or \code{SummarizedExperiment} object,
+#'   or \code{invisible(NULL)} when \code{download_only = TRUE}.
 #' @importFrom httr parse_url
 #' @importFrom dplyr transmute distinct mutate
 #' @importFrom purrr pmap imap map map_lgl map2 reduce
@@ -458,7 +486,8 @@ get_metacell <- function(data,
   grouping_column,
   features,
   metacell_column = NULL,
-  coldata_columns = NULL
+  coldata_columns = NULL,
+  download_only = FALSE
 ) {
   subdirs <- assay_map[assays]
 
@@ -507,29 +536,28 @@ get_metacell <- function(data,
     }
   }
 
-  cli_alert_info("Reading files.")
-
   # Group by file only, not by dir_prefix
   groups <- raw_data |>
     group_split(.data[[grouping_column]])
 
-  # For SCT, some samples may have no h5ad file (normalisation failed).
-  # Drop those groups now so all per-assay experiment lists stay aligned.
+  # For SCT, some samples may have no h5ad file (normalisation failed for that
+  # sample so no SCT file was written to the store).
   if ("sct" %in% assays) {
     groups_with_sct <- .skip_groups_missing_sct_file(
       groups, cache_directory, cell_aggregation, grouping_column
     )
 
     if (length(groups_with_sct) == 0L) {
-      # No SCT files at all. When other assays were also requested, fall back to
-      # returning those for ALL groups. When SCT was the only assay, abort.
+      # No SCT files at all. In download_only mode a warning suffices; in
+      # read mode, fall back to other assays or abort if SCT was the only one.
       other_assays <- setdiff(assays, "sct")
       if (length(other_assays) == 0L) {
-        cli_abort(paste(
-          "cellNexus says: No groups remain after removing samples with missing SCT files.",
-          "SCT normalisation appears to have failed for every sample in your query.",
+        cli_alert_warning(paste(
+          "cellNexus says: No SCT files were found for any sample in your query.",
+          "SCT normalisation appears to have failed for every sample.",
           "Try a different set of samples or use assays = \"counts\" instead."
         ))
+        return(NULL)
       }
       cli_alert_warning(paste(
         "cellNexus says: No SCT files were found for any sample in your query.",
@@ -543,6 +571,12 @@ get_metacell <- function(data,
       groups <- groups_with_sct
     }
   }
+
+  if (download_only) {
+    return(invisible(NULL))
+  }
+
+  cli_alert_info("Reading files.")
 
   # Outer imap iterates over assays; each assay gets its own labelled progress bar.
   # This also fixes dir_prefix construction: current_subdir is properly scoped here.

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -12,9 +12,13 @@ as.sparse.DelayedMatrix <- function(x, ...) {
 #' the samples in that data frame
 #'
 #' @inheritDotParams get_single_cell_experiment
+#' @param download_only Logical scalar. When `TRUE`, remote files are
+#'   synchronised to `cache_directory` but not read or assembled. Returns
+#'   `invisible(NULL)`. See [get_single_cell_experiment()] for details.
 #' @export
 #' @return A Seurat object containing the same data as a call to
-#'   [get_single_cell_experiment()]. All requested assays are present in the
+#'   [get_single_cell_experiment()], or `invisible(NULL)` when
+#'   `download_only = TRUE`. All requested assays are present in the
 #'   returned object under their original names (e.g. `"counts"`, `"cpm"`).
 #' @importFrom SummarizedExperiment assayNames assay
 #' @examples
@@ -28,10 +32,14 @@ as.sparse.DelayedMatrix <- function(x, ...) {
 #'   and analytical layers for the Human Cell Atlas data." bioRxiv (2026).
 #'   doi:10.64898/2026.04.14.718336.
 #' @source [Shen et al.,2026](https://www.biorxiv.org/content/10.64898/2026.04.14.718336v3)
-get_seurat <- function(...) {
+get_seurat <- function(..., download_only = FALSE) {
   rlang::check_installed(c("Seurat", "SeuratObject"))
 
-  sce <- get_single_cell_experiment(...)
+  sce <- get_single_cell_experiment(..., download_only = download_only)
+
+  if (download_only) {
+    return(invisible(NULL))
+  }
 
   sce_assays <- assayNames(sce)
   first_assay <- sce_assays[1]

--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ CELLxGENE releases.
 
 </div>
 
+# Repositories
+
+### R API: [here](https://github.com/MangiolaLaboratory/cellNexus)
+
+### Python API: [here](https://github.com/MangiolaLaboratory/cellNexusPy/)
+
+### Article code: [here](https://github.com/MangiolaLaboratory/cellNexus_article)
+
+
 # Query interface
 
 ## Installation
@@ -258,7 +267,7 @@ Reading counts ■■■■■■■■■■■■■■■■■■■■■�
 
 single_cell_counts
 #> # A SingleCellExperiment-tibble abstraction: 2,806 × 54
-#> # [90mFeatures=33145 | Cells=2806 | Assays=counts[0m
+#> # [90mFeatures=33145 | Cells=2806 | Assays=counts[0m
 #>    .cell observation_joinid dataset_id sample_id donor_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA empty_droplet
 #>    <chr> <chr>              <chr>      <chr>     <chr>       <int> <chr>                          <int>      <dbl> <lgl>        
 #>  1 80_1  zz-!e5_XAo         842c6f5d-… 1de3f3ba… P58         14600 breast                          1749      10.8  FALSE        
@@ -317,7 +326,7 @@ Reading cpm ■■■■■■■■■■■■■■■■■■■■■■�
 
 single_cell_cpm
 #> # A SingleCellExperiment-tibble abstraction: 2,806 × 54
-#> # [90mFeatures=33145 | Cells=2806 | Assays=cpm[0m
+#> # [90mFeatures=33145 | Cells=2806 | Assays=cpm[0m
 #>    .cell observation_joinid dataset_id sample_id donor_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA empty_droplet
 #>    <chr> <chr>              <chr>      <chr>     <chr>       <int> <chr>                          <int>      <dbl> <lgl>        
 #>  1 76_1  bTlx!HK=oS         842c6f5d-… 52ab9222… P58         14600 breast                          1671       9.65 FALSE        
@@ -390,7 +399,7 @@ Reading sct ■■■■■■■■■■■■■■■■■■■■■■�
 
 single_cell_sct
 #> # A SingleCellExperiment-tibble abstraction: 1,193 × 54
-#> # [90mFeatures=33145 | Cells=1193 | Assays=sct[0m
+#> # [90mFeatures=33145 | Cells=1193 | Assays=sct[0m
 #>    .cell observation_joinid dataset_id sample_id donor_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA empty_droplet
 #>    <chr> <chr>              <chr>      <chr>     <chr>       <int> <chr>                          <int>      <dbl> <lgl>        
 #>  1 80_1  zz-!e5_XAo         842c6f5d-… 1de3f3ba… P58         14600 breast                          1749      10.8  FALSE        
@@ -445,7 +454,7 @@ Reading counts ■■■■■■■■■■■■■■■■■■■■■�
 
 pseudobulk_counts
 #> # A SingleCellExperiment-tibble abstraction: 146 × 46
-#> # [90mFeatures=15888 | Cells=146 | Assays=counts[0m
+#> # [90mFeatures=15888 | Cells=146 | Assays=counts[0m
 #>    .cell  sample_id cell_type_unified_en…¹ dataset_id donor_id age_days tissue_groups empty_droplet is_immune high_mitochondrion
 #>    <chr>  <chr>     <chr>                  <chr>      <chr>       <int> <chr>         <lgl>         <lgl>     <lgl>             
 #>  1 2e8c9… 2e8c9911… cd14 mono              0ba16f4b-… HDBR152…       NA respiratory … FALSE         TRUE      FALSE             
@@ -545,7 +554,7 @@ Reading cpm ■■■■■■■■■■■■■■■■■■■■■■�
 
 single_cell_cpm
 #> # A SingleCellExperiment-tibble abstraction: 2,806 × 54
-#> # [90mFeatures=1 | Cells=2806 | Assays=cpm[0m
+#> # [90mFeatures=1 | Cells=2806 | Assays=cpm[0m
 #>    .cell observation_joinid dataset_id sample_id donor_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA empty_droplet
 #>    <chr> <chr>              <chr>      <chr>     <chr>       <int> <chr>                          <int>      <dbl> <lgl>        
 #>  1 76_1  bTlx!HK=oS         842c6f5d-… 52ab9222… P58         14600 breast                          1671       9.65 FALSE        
@@ -608,7 +617,7 @@ Reading counts ■■■■■■■■■■■■■■■■■■■■■�
 
 seurat_counts
 #> # A Seurat-tibble abstraction: 2,806 × 59
-#> # [90mFeatures=33145 | Cells=2806 | Active assay=counts | Assays=counts[0m
+#> # [90mFeatures=33145 | Cells=2806 | Active assay=counts | Assays=counts[0m
 #>    .cell orig.ident    nCount_originalexp nFeature_originalexp observation_joinid dataset_id         sample_id donor_id age_days
 #>    <chr> <fct>                      <dbl>                <int> <chr>              <chr>              <chr>     <chr>       <int>
 #>  1 73_1  SeuratProject               14.1                 2958 z_=CTOs4{z         842c6f5d-4a94-4ee… 4b5e66fa… P39         14600
@@ -860,7 +869,7 @@ get_metadata(
 #> ℹ Reading files.
 #> ℹ Compiling Experiment.
 #> # A SingleCellExperiment-tibble abstraction: 500 × 7
-#> # [90mFeatures=13132 | Cells=500 | Assays=counts[0m
+#> # [90mFeatures=13132 | Cells=500 | Assays=counts[0m
 #>    .cell            sample_id dataset_id cell_type_unified_ensemble atlas_id             file_id_cellNexus_sing…¹ original_cell_
 #>    <chr>            <chr>     <chr>      <chr>                      <chr>                <chr>                    <chr>         
 #>  1 AAACATACAACCAC_1 pbmc3k    pbmc3k     Memory CD4 T               cellxgene/03-10-2025 67e196a3c4e145151fc9e06… AAACATACAACCAC

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,6 +1,30 @@
 \name{NEWS}
 \title{News for Package \pkg{cellNexus}}
 
+\section{News in version 0.99.32}{
+\itemize{
+    \item Added \code{download_only} argument (default \code{FALSE}) to
+    \code{get_single_cell_experiment()}, \code{get_seurat()}, and
+    \code{get_pseudobulk()}.
+    \itemize{
+        \item When \code{TRUE}, remote files are synchronised to
+        \code{cache_directory} but are not read or assembled into an
+        in-memory object.
+        \item Quality-control filtering (\code{keep_quality_cells()}) is
+        applied automatically in both modes, so only the files required for
+        quality-controlled cells are downloaded. A warning is emitted when
+        cells are excluded so users are informed even if they omit
+        \code{keep_quality_cells()} explicitly.
+        \item For the \code{sct} assay, the post-sync missing-file check
+        (\code{.skip_groups_missing_sct_file()}) now runs before the
+        \code{download_only} early return, so warnings about samples whose
+        SCT normalisation failed are emitted regardless of mode.
+        \item When \code{assays = "sct"} only and every sample is missing
+        its SCT file, the function emits a warning and returns
+        \code{invisible(NULL)} instead of aborting.
+    }
+}}
+
 \section{News in version 0.99.31}{
 \itemize{
     \item Added \code{donor_id} to harmonised metadata, enabling direct donor-level
@@ -52,10 +76,10 @@
 \section{News in version 0.99.27}{
 \itemize{
     \item \code{get_pseudobulk()} now retains metadata columns that are constant within each
-    \code{sample_id} \(\times\) \code{cell_type_unified_ensemble} combination, including
+    \code{sample_id} x \code{cell_type_unified_ensemble} combination, including
     user-added annotations, when building \code{colData}. Cell-level columns are dropped.
     \item \code{get_metacell()} uses the same once-per-query column selection for
-    \code{sample_id} \(\times\) metacell-level annotations, so \code{cbind()} across
+    \code{sample_id} x metacell-level annotations, so \code{cbind()} across
     files shares an identical \code{colData} schema.
     \item Added internal helpers \code{get_specific_annotation_columns()} and
     \code{keep_specific_annotation_columns()} to identify and keep columns functionally

--- a/man/get_SingleCellExperiment.Rd
+++ b/man/get_SingleCellExperiment.Rd
@@ -33,6 +33,10 @@ files should be copied.}
 an HTTP URL pointing to the location where the single cell data is stored.}
     \item{\code{features}}{An optional character vector of features (ie genes) to return
 the counts for. By default counts for all features will be returned.}
+    \item{\code{download_only}}{Logical scalar. When \code{TRUE}, remote files are
+synchronised to \code{cache_directory} but the data is not read or assembled
+into an in-memory object. Returns \code{invisible(NULL)}. Useful for
+pre-fetching datasets only.}
   }}
 }
 \value{

--- a/man/get_pseudobulk.Rd
+++ b/man/get_pseudobulk.Rd
@@ -14,7 +14,8 @@ get_pseudobulk(
   cache_directory = get_default_cache_dir(),
   repository = COUNTS_URL,
   features = NULL,
-  as_SummarizedExperiment = FALSE
+  as_SummarizedExperiment = FALSE,
+  download_only = FALSE
 )
 }
 \arguments{
@@ -49,11 +50,18 @@ A warning is emitted when samples are dropped.}
 
 \item{as_SummarizedExperiment}{If \code{TRUE}, coerce the result to a
 \code{SummarizedExperiment}. Note that \code{as(x, "SummarizedExperiment")} drops
-feature rownames; \code{get_pseudobulk()} restores them after coercion.}
+feature rownames; \code{get_pseudobulk()} restores them after coercion.
+Ignored when \code{download_only = TRUE}.}
+
+\item{download_only}{Logical scalar. When \code{TRUE}, remote files are
+synchronised to \code{cache_directory} but the data is not read or assembled
+into an in-memory object. Returns \code{invisible(NULL)}. Useful for
+pre-fetching datasets only.}
 }
 \value{
 By default, a \code{SingleCellExperiment} object. If
 \code{as_SummarizedExperiment} is \code{TRUE}, a \code{SummarizedExperiment} object.
+Returns \code{invisible(NULL)} when \code{download_only = TRUE}.
 }
 \description{
 Given a data frame of Curated Atlas metadata obtained from \code{\link[=get_metadata]{get_metadata()}},

--- a/man/get_seurat.Rd
+++ b/man/get_seurat.Rd
@@ -8,7 +8,7 @@ the samples in that data frame}
 \href{https://www.biorxiv.org/content/10.64898/2026.04.14.718336v3}{Shen et al.,2026}
 }
 \usage{
-get_seurat(...)
+get_seurat(..., download_only = FALSE)
 }
 \arguments{
 \item{...}{
@@ -35,10 +35,15 @@ an HTTP URL pointing to the location where the single cell data is stored.}
     \item{\code{features}}{An optional character vector of features (ie genes) to return
 the counts for. By default counts for all features will be returned.}
   }}
+
+\item{download_only}{Logical scalar. When \code{TRUE}, remote files are
+synchronised to \code{cache_directory} but not read or assembled. Returns
+\code{invisible(NULL)}. See \code{\link[=get_single_cell_experiment]{get_single_cell_experiment()}} for details.}
 }
 \value{
 A Seurat object containing the same data as a call to
-\code{\link[=get_single_cell_experiment]{get_single_cell_experiment()}}. All requested assays are present in the
+\code{\link[=get_single_cell_experiment]{get_single_cell_experiment()}}, or \code{invisible(NULL)} when
+\code{download_only = TRUE}. All requested assays are present in the
 returned object under their original names (e.g. \code{"counts"}, \code{"cpm"}).
 }
 \description{

--- a/man/get_single_cell_experiment.Rd
+++ b/man/get_single_cell_experiment.Rd
@@ -13,7 +13,8 @@ get_single_cell_experiment(
   cell_aggregation = "",
   cache_directory = get_default_cache_dir(),
   repository = COUNTS_URL,
-  features = NULL
+  features = NULL,
+  download_only = FALSE
 )
 }
 \arguments{
@@ -42,9 +43,15 @@ an HTTP URL pointing to the location where the single cell data is stored.}
 
 \item{features}{An optional character vector of features (ie genes) to return
 the counts for. By default counts for all features will be returned.}
+
+\item{download_only}{Logical scalar. When \code{TRUE}, remote files are
+synchronised to \code{cache_directory} but the data is not read or assembled
+into an in-memory object. Returns \code{invisible(NULL)}. Useful for
+pre-fetching datasets only.}
 }
 \value{
-A \code{SingleCellExperiment} object.
+A \code{SingleCellExperiment} object, or \code{invisible(NULL)} when
+\code{download_only = TRUE}.
 }
 \description{
 Given a data frame of Curated Atlas metadata obtained from \code{\link[=get_metadata]{get_metadata()}},

--- a/vignettes/cellNexus.Rmd
+++ b/vignettes/cellNexus.Rmd
@@ -54,6 +54,15 @@ While both cellNexus and CuratedAtlasQueryR rely on precomputed expression layer
 <p class="caption">plot of chunk fig-funders</p>
 </div>
 
+# Repositories
+
+### R API: [here](https://github.com/MangiolaLaboratory/cellNexus)
+
+### Python API: [here](https://github.com/MangiolaLaboratory/cellNexusPy/)
+
+### Article code: [here](https://github.com/MangiolaLaboratory/cellNexus_article)
+
+
 # Query interface
 
 ## Installation
@@ -196,11 +205,29 @@ single_cell_counts <-
 #> ℹ Realising metadata.
 #> ℹ Synchronising files
 #> ℹ Reading files.
-#> Reading counts ■■■■■■■                           20% | ETA:  9sReading counts ■■■■■■■■■■                        30% | ETA:  7sReading counts ■■■■■■■■■■■■■                     40% | ETA:  5sReading counts ■■■■■■■■■■■■■■■■                  50% | ETA:  4sReading counts ■■■■■■■■■■■■■■■■■■■               60% | ETA:  3sReading counts ■■■■■■■■■■■■■■■■■■■■■■            70% | ETA:  2sReading counts ■■■■■■■■■■■■■■■■■■■■■■■■■         80% | ETA:  1sReading counts ■■■■■■■■■■■■■■■■■■■■■■■■■■■■      90% | ETA:  1s                                                                ℹ Compiling Experiment.
+#> 
+Reading counts ■■■■■■■                           20% | ETA:  9s
+
+Reading counts ■■■■■■■■■■                        30% | ETA:  7s
+
+Reading counts ■■■■■■■■■■■■■                     40% | ETA:  5s
+
+Reading counts ■■■■■■■■■■■■■■■■                  50% | ETA:  4s
+
+Reading counts ■■■■■■■■■■■■■■■■■■■               60% | ETA:  3s
+
+Reading counts ■■■■■■■■■■■■■■■■■■■■■■            70% | ETA:  2s
+
+Reading counts ■■■■■■■■■■■■■■■■■■■■■■■■■         80% | ETA:  1s
+
+Reading counts ■■■■■■■■■■■■■■■■■■■■■■■■■■■■      90% | ETA:  1s
+
+                                                                
+ℹ Compiling Experiment.
 
 single_cell_counts
 #> # A SingleCellExperiment-tibble abstraction: 2,806 × 54
-#> # [90mFeatures=33145 | Cells=2806 | Assays=counts[0m
+#> # [90mFeatures=33145 | Cells=2806 | Assays=counts[0m
 #>    .cell observation_joinid dataset_id sample_id donor_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA empty_droplet
 #>    <chr> <chr>              <chr>      <chr>     <chr>       <int> <chr>                          <int>      <dbl> <lgl>        
 #>  1 80_1  zz-!e5_XAo         842c6f5d-… 1de3f3ba… P58         14600 breast                          1749      10.8  FALSE        
@@ -238,11 +265,29 @@ single_cell_cpm <-
 #> ℹ Realising metadata.
 #> ℹ Synchronising files
 #> ℹ Reading files.
-#> Reading cpm ■■■■■■■                           20% | ETA:  6sReading cpm ■■■■■■■■■■                        30% | ETA:  4sReading cpm ■■■■■■■■■■■■■                     40% | ETA:  4sReading cpm ■■■■■■■■■■■■■■■■                  50% | ETA:  3sReading cpm ■■■■■■■■■■■■■■■■■■■               60% | ETA:  3sReading cpm ■■■■■■■■■■■■■■■■■■■■■■            70% | ETA:  2sReading cpm ■■■■■■■■■■■■■■■■■■■■■■■■■         80% | ETA:  1sReading cpm ■■■■■■■■■■■■■■■■■■■■■■■■■■■■      90% | ETA:  1s                                                             ℹ Compiling Experiment.
+#> 
+Reading cpm ■■■■■■■                           20% | ETA:  6s
+
+Reading cpm ■■■■■■■■■■                        30% | ETA:  4s
+
+Reading cpm ■■■■■■■■■■■■■                     40% | ETA:  4s
+
+Reading cpm ■■■■■■■■■■■■■■■■                  50% | ETA:  3s
+
+Reading cpm ■■■■■■■■■■■■■■■■■■■               60% | ETA:  3s
+
+Reading cpm ■■■■■■■■■■■■■■■■■■■■■■            70% | ETA:  2s
+
+Reading cpm ■■■■■■■■■■■■■■■■■■■■■■■■■         80% | ETA:  1s
+
+Reading cpm ■■■■■■■■■■■■■■■■■■■■■■■■■■■■      90% | ETA:  1s
+
+                                                             
+ℹ Compiling Experiment.
 
 single_cell_cpm
 #> # A SingleCellExperiment-tibble abstraction: 2,806 × 54
-#> # [90mFeatures=33145 | Cells=2806 | Assays=cpm[0m
+#> # [90mFeatures=33145 | Cells=2806 | Assays=cpm[0m
 #>    .cell observation_joinid dataset_id sample_id donor_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA empty_droplet
 #>    <chr> <chr>              <chr>      <chr>     <chr>       <int> <chr>                          <int>      <dbl> <lgl>        
 #>  1 76_1  bTlx!HK=oS         842c6f5d-… 52ab9222… P58         14600 breast                          1671       9.65 FALSE        
@@ -280,15 +325,42 @@ single_cell_sct <-
 #> ℹ Synchronising files
 #> ℹ Reading files.
 #> ! The number of cells in the SingleCellExperiment will be less than the number of cells you have selected from the metadata. Are cell IDs duplicated? Or, do cell IDs correspond to the counts file?
-#> Reading sct ■■■■■■■                           20% | ETA:  5sReading sct ■■■■■■■■■■                        30% | ETA:  4sReading sct ■■■■■■■■■■■■■                     40% | ETA:  4s                                                             ! The number of cells in the SingleCellExperiment will be less than the number of cells you have selected from the metadata. Are cell IDs duplicated? Or, do cell IDs correspond to the counts file?
-#> Reading sct ■■■■■■■■■■■■■                     40% | ETA:  4sReading sct ■■■■■■■■■■■■■■■■                  50% | ETA:  3s                                                             ! The number of cells in the SingleCellExperiment will be less than the number of cells you have selected from the metadata. Are cell IDs duplicated? Or, do cell IDs correspond to the counts file?
-#> Reading sct ■■■■■■■■■■■■■■■■                  50% | ETA:  3sReading sct ■■■■■■■■■■■■■■■■■■■               60% | ETA:  2sReading sct ■■■■■■■■■■■■■■■■■■■■■■            70% | ETA:  2s                                                             ! The number of cells in the SingleCellExperiment will be less than the number of cells you have selected from the metadata. Are cell IDs duplicated? Or, do cell IDs correspond to the counts file?
-#> Reading sct ■■■■■■■■■■■■■■■■■■■■■■            70% | ETA:  2sReading sct ■■■■■■■■■■■■■■■■■■■■■■■■■         80% | ETA:  1sReading sct ■■■■■■■■■■■■■■■■■■■■■■■■■■■■      90% | ETA:  1s                                                             ! cellNexus says: 1613 cell(s) from your metadata are absent from the SCT assay across 4 file(s). This is expected: SCT normalisation is run per sample and may fail for samples with very few cells or extreme count distributions. The returned object contains only cells from samples where SCT succeeded. Affected sample_id(s): 52ab92226337d36c306466eefe67f9c1, 765554078ca8d1eaf2712000c0df0d6f, 8940e0767e7eca1b72d37b4138be2276, a79912cb9aaa8d8c0b1a3cdcc9294f8c, 5e641a2218d1d8b91f638989626c89e0.
+#> 
+Reading sct ■■■■■■■                           20% | ETA:  5s
+
+Reading sct ■■■■■■■■■■                        30% | ETA:  4s
+
+Reading sct ■■■■■■■■■■■■■                     40% | ETA:  4s
+
+                                                             
+! The number of cells in the SingleCellExperiment will be less than the number of cells you have selected from the metadata. Are cell IDs duplicated? Or, do cell IDs correspond to the counts file?
+#> Reading sct ■■■■■■■■■■■■■                     40% | ETA:  4s
+
+Reading sct ■■■■■■■■■■■■■■■■                  50% | ETA:  3s
+
+                                                             
+! The number of cells in the SingleCellExperiment will be less than the number of cells you have selected from the metadata. Are cell IDs duplicated? Or, do cell IDs correspond to the counts file?
+#> Reading sct ■■■■■■■■■■■■■■■■                  50% | ETA:  3s
+
+Reading sct ■■■■■■■■■■■■■■■■■■■               60% | ETA:  2s
+
+Reading sct ■■■■■■■■■■■■■■■■■■■■■■            70% | ETA:  2s
+
+                                                             
+! The number of cells in the SingleCellExperiment will be less than the number of cells you have selected from the metadata. Are cell IDs duplicated? Or, do cell IDs correspond to the counts file?
+#> Reading sct ■■■■■■■■■■■■■■■■■■■■■■            70% | ETA:  2s
+
+Reading sct ■■■■■■■■■■■■■■■■■■■■■■■■■         80% | ETA:  1s
+
+Reading sct ■■■■■■■■■■■■■■■■■■■■■■■■■■■■      90% | ETA:  1s
+
+                                                             
+! cellNexus says: 1613 cell(s) from your metadata are absent from the SCT assay across 4 file(s). This is expected: SCT normalisation is run per sample and may fail for samples with very few cells or extreme count distributions. The returned object contains only cells from samples where SCT succeeded. Affected sample_id(s): 52ab92226337d36c306466eefe67f9c1, 765554078ca8d1eaf2712000c0df0d6f, 8940e0767e7eca1b72d37b4138be2276, a79912cb9aaa8d8c0b1a3cdcc9294f8c, 5e641a2218d1d8b91f638989626c89e0.
 #> ℹ Compiling Experiment.
 
 single_cell_sct
 #> # A SingleCellExperiment-tibble abstraction: 1,193 × 54
-#> # [90mFeatures=33145 | Cells=1193 | Assays=sct[0m
+#> # [90mFeatures=33145 | Cells=1193 | Assays=sct[0m
 #>    .cell observation_joinid dataset_id sample_id donor_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA empty_droplet
 #>    <chr> <chr>              <chr>      <chr>     <chr>       <int> <chr>                          <int>      <dbl> <lgl>        
 #>  1 80_1  zz-!e5_XAo         842c6f5d-… 1de3f3ba… P58         14600 breast                          1749      10.8  FALSE        
@@ -324,12 +396,26 @@ pseudobulk_counts <-
 #> ℹ Realising metadata.
 #> ℹ Synchronising files
 #> ℹ Reading files.
-#> Reading counts ■■■■■                             14% | ETA:  9sReading counts ■■■■■■■■■■                        29% | ETA:  9sReading counts ■■■■■■■■■■■■■■                    43% | ETA:  7sReading counts ■■■■■■■■■■■■■■■■■■                57% | ETA:  5sReading counts ■■■■■■■■■■■■■■■■■■■■■■            71% | ETA:  4sReading counts ■■■■■■■■■■■■■■■■■■■■■■■■■■■       86% | ETA:  2s                                                                ! cellNexus says: Not all genes completely overlap across the provided objects. Counts are generated by genes intersection.
+#> 
+Reading counts ■■■■■                             14% | ETA:  9s
+
+Reading counts ■■■■■■■■■■                        29% | ETA:  9s
+
+Reading counts ■■■■■■■■■■■■■■                    43% | ETA:  7s
+
+Reading counts ■■■■■■■■■■■■■■■■■■                57% | ETA:  5s
+
+Reading counts ■■■■■■■■■■■■■■■■■■■■■■            71% | ETA:  4s
+
+Reading counts ■■■■■■■■■■■■■■■■■■■■■■■■■■■       86% | ETA:  2s
+
+                                                                
+! cellNexus says: Not all genes completely overlap across the provided objects. Counts are generated by genes intersection.
 #> ℹ Compiling Experiment.
 
 pseudobulk_counts
 #> # A SingleCellExperiment-tibble abstraction: 146 × 46
-#> # [90mFeatures=15888 | Cells=146 | Assays=counts[0m
+#> # [90mFeatures=15888 | Cells=146 | Assays=counts[0m
 #>    .cell  sample_id cell_type_unified_en…¹ dataset_id donor_id age_days tissue_groups empty_droplet is_immune high_mitochondrion
 #>    <chr>  <chr>     <chr>                  <chr>      <chr>       <int> <chr>         <lgl>         <lgl>     <lgl>             
 #>  1 2e8c9… 2e8c9911… cd14 mono              0ba16f4b-… HDBR152…       NA respiratory … FALSE         TRUE      FALSE             
@@ -397,11 +483,29 @@ single_cell_cpm <-
 #> ℹ Realising metadata.
 #> ℹ Synchronising files
 #> ℹ Reading files.
-#> Reading cpm ■■■■■■■                           20% | ETA:  4sReading cpm ■■■■■■■■■■                        30% | ETA:  4sReading cpm ■■■■■■■■■■■■■                     40% | ETA:  3sReading cpm ■■■■■■■■■■■■■■■■                  50% | ETA:  3sReading cpm ■■■■■■■■■■■■■■■■■■■               60% | ETA:  2sReading cpm ■■■■■■■■■■■■■■■■■■■■■■            70% | ETA:  2sReading cpm ■■■■■■■■■■■■■■■■■■■■■■■■■         80% | ETA:  1sReading cpm ■■■■■■■■■■■■■■■■■■■■■■■■■■■■      90% | ETA:  1s                                                             ℹ Compiling Experiment.
+#> 
+Reading cpm ■■■■■■■                           20% | ETA:  4s
+
+Reading cpm ■■■■■■■■■■                        30% | ETA:  4s
+
+Reading cpm ■■■■■■■■■■■■■                     40% | ETA:  3s
+
+Reading cpm ■■■■■■■■■■■■■■■■                  50% | ETA:  3s
+
+Reading cpm ■■■■■■■■■■■■■■■■■■■               60% | ETA:  2s
+
+Reading cpm ■■■■■■■■■■■■■■■■■■■■■■            70% | ETA:  2s
+
+Reading cpm ■■■■■■■■■■■■■■■■■■■■■■■■■         80% | ETA:  1s
+
+Reading cpm ■■■■■■■■■■■■■■■■■■■■■■■■■■■■      90% | ETA:  1s
+
+                                                             
+ℹ Compiling Experiment.
 
 single_cell_cpm
 #> # A SingleCellExperiment-tibble abstraction: 2,806 × 54
-#> # [90mFeatures=1 | Cells=2806 | Assays=cpm[0m
+#> # [90mFeatures=1 | Cells=2806 | Assays=cpm[0m
 #>    .cell observation_joinid dataset_id sample_id donor_id age_days tissue_groups nFeature_expressed_i…¹ nCount_RNA empty_droplet
 #>    <chr> <chr>              <chr>      <chr>     <chr>       <int> <chr>                          <int>      <dbl> <lgl>        
 #>  1 76_1  bTlx!HK=oS         842c6f5d-… 52ab9222… P58         14600 breast                          1671       9.65 FALSE        
@@ -441,11 +545,29 @@ seurat_counts <-
 #> ℹ Realising metadata.
 #> ℹ Synchronising files
 #> ℹ Reading files.
-#> Reading counts ■■■■■■■                           20% | ETA:  4sReading counts ■■■■■■■■■■                        30% | ETA:  4sReading counts ■■■■■■■■■■■■■                     40% | ETA:  3sReading counts ■■■■■■■■■■■■■■■■                  50% | ETA:  3sReading counts ■■■■■■■■■■■■■■■■■■■               60% | ETA:  2sReading counts ■■■■■■■■■■■■■■■■■■■■■■            70% | ETA:  2sReading counts ■■■■■■■■■■■■■■■■■■■■■■■■■         80% | ETA:  1sReading counts ■■■■■■■■■■■■■■■■■■■■■■■■■■■■      90% | ETA:  1s                                                                ℹ Compiling Experiment.
+#> 
+Reading counts ■■■■■■■                           20% | ETA:  4s
+
+Reading counts ■■■■■■■■■■                        30% | ETA:  4s
+
+Reading counts ■■■■■■■■■■■■■                     40% | ETA:  3s
+
+Reading counts ■■■■■■■■■■■■■■■■                  50% | ETA:  3s
+
+Reading counts ■■■■■■■■■■■■■■■■■■■               60% | ETA:  2s
+
+Reading counts ■■■■■■■■■■■■■■■■■■■■■■            70% | ETA:  2s
+
+Reading counts ■■■■■■■■■■■■■■■■■■■■■■■■■         80% | ETA:  1s
+
+Reading counts ■■■■■■■■■■■■■■■■■■■■■■■■■■■■      90% | ETA:  1s
+
+                                                                
+ℹ Compiling Experiment.
 
 seurat_counts
 #> # A Seurat-tibble abstraction: 2,806 × 59
-#> # [90mFeatures=33145 | Cells=2806 | Active assay=counts | Assays=counts[0m
+#> # [90mFeatures=33145 | Cells=2806 | Active assay=counts | Assays=counts[0m
 #>    .cell orig.ident    nCount_originalexp nFeature_originalexp observation_joinid dataset_id         sample_id donor_id age_days
 #>    <chr> <fct>                      <dbl>                <int> <chr>              <chr>              <chr>     <chr>       <int>
 #>  1 73_1  SeuratProject               14.1                 2958 z_=CTOs4{z         842c6f5d-4a94-4ee… 4b5e66fa… P39         14600
@@ -674,7 +796,7 @@ get_metadata(
 #> ℹ Reading files.
 #> ℹ Compiling Experiment.
 #> # A SingleCellExperiment-tibble abstraction: 500 × 7
-#> # [90mFeatures=13132 | Cells=500 | Assays=counts[0m
+#> # [90mFeatures=13132 | Cells=500 | Assays=counts[0m
 #>    .cell            sample_id dataset_id cell_type_unified_ensemble atlas_id             file_id_cellNexus_sing…¹ original_cell_
 #>    <chr>            <chr>     <chr>      <chr>                      <chr>                <chr>                    <chr>         
 #>  1 AAACATACAACCAC_1 pbmc3k    pbmc3k     Memory CD4 T               cellxgene/03-10-2025 67e196a3c4e145151fc9e06… AAACATACAACCAC

--- a/vignettes/cellNexus.Rmd.orig
+++ b/vignettes/cellNexus.Rmd.orig
@@ -56,6 +56,15 @@ c(
   knitr::include_graphics()
 ```
 
+# Repositories
+
+### R API: [here](https://github.com/MangiolaLaboratory/cellNexus)
+
+### Python API: [here](https://github.com/MangiolaLaboratory/cellNexusPy/)
+
+### Article code: [here](https://github.com/MangiolaLaboratory/cellNexus_article)
+
+
 # Query interface
 
 ## Installation


### PR DESCRIPTION
Addressed issue #147
Download single-cell:
```
my_cache = tempdir()
get_metadata(cache_directory = my_cache) |> 
  get_single_cell_experiment(assays = c("counts", "cpm", "rank", "sct"), cache_directory = my_cache, download_only = TRUE)
```

Download pseudobulk:
```
get_metadata(cache_directory = my_cache) |> 
  get_pseudobulk(assays = "counts", cache_directory = my_cache, download_only = TRUE)
```